### PR TITLE
Variable Declaration

### DIFF
--- a/isar/lib/src/native/isar_core.dart
+++ b/isar/lib/src/native/isar_core.dart
@@ -1,5 +1,7 @@
 part of isar_native;
 
+const falseBool = 1;
+const trueBool = 2;
 const minBool = nullBool;
 const maxBool = trueBool;
 const minInt = -2147483648;
@@ -16,8 +18,6 @@ const nullFloat = double.nan;
 const nullLong = minLong;
 const nullDouble = double.nan;
 const nullBool = 0;
-const falseBool = 1;
-const trueBool = 2;
 
 class IsarCoreUtils {
   static final syncTxnPtr = allocate<Pointer>();

--- a/isar_generator/lib/src/code_gen/util.dart
+++ b/isar_generator/lib/src/code_gen/util.dart
@@ -1,5 +1,3 @@
-import 'package:isar_generator/src/object_info.dart';
-
 import 'package:dartx/dartx.dart';
 
 String getCollectionVar(String objectType) =>


### PR DESCRIPTION
Removed unused imports
The variable should be declared first before using it.