### PR TITLE
Fix bad reference to renamed properties

### DIFF
--- a/packages/isar_generator/lib/src/code_gen/object_adapter_generator.dart
+++ b/packages/isar_generator/lib/src/code_gen/object_adapter_generator.dart
@@ -196,7 +196,7 @@ String _generateDeserialize(ObjectInfo object) {
     final object = ${object.dartName}();''';
   for (var i = 0; i < object.properties.length; i++) {
     final property = object.properties[i];
-    final accessor = 'object.${property.isarName}';
+    final accessor = 'object.${property.dartName}';
     final deser = _deserializeProperty(object, property, 'offsets[$i]');
     code += '$accessor = $deser;';
   }


### PR DESCRIPTION
When a property in a collection have a `@Name()` annotation, Isar use that name as the property name, which leads to errors in the generated code.

This PR just comes with a simple fix for that.

@leisim 