### PR TITLE
Properly ignore getters and setters

### DIFF
--- a/packages/isar_generator/lib/src/isar_analyzer.dart
+++ b/packages/isar_generator/lib/src/isar_analyzer.dart
@@ -455,6 +455,11 @@ class IsarAnalyzer extends Builder {
   }
 
   bool checkField(PropertyInducingElement element) {
+    // Skip static fields
+    if (element.isStatic) {
+      return false;
+    }
+
     // Check if the element is a pure getter (no setter defined)
     if (element.setter == null) {
       return false;


### PR DESCRIPTION
Fixes #93

This PR aims to fix the issue on the generator which doesn't work when the model class has a getter of any type. Since isar use fields for data mapping with the database, I've just updated the generator to ignore any getter/setter from the model class, and it works well now (at least, with the project I'm working on).

@leisim @ebadta81