### PR TITLE
[isar] fix `FilterGroup.not` return wrong `FilterGroupType`

### DIFF
--- a/packages/isar/lib/src/query_components.dart
+++ b/packages/isar/lib/src/query_components.dart
@@ -120,7 +120,7 @@ class FilterGroup extends FilterOperation {
 
   FilterGroup.not(FilterOperation filter)
       : filters = [filter],
-        type = FilterGroupType.or;
+        type = FilterGroupType.not;
 }
 
 /// Sort order


### PR DESCRIPTION
Currently, FilterGroup.not() => FilterGroupType.or.

This PR fix that.