### PR TITLE
do not force a write txn for loadSync

### DIFF
--- a/packages/isar/lib/src/native/isar_link_impl.dart
+++ b/packages/isar/lib/src/native/isar_link_impl.dart
@@ -58,7 +58,7 @@ class IsarLinkImpl<OBJ> extends IsarLinkCommon<OBJ> with IsarBaseMixin<OBJ> {
   @override
   void loadSync() {
     final containingId = requireAttached();
-    col.isar.getTxnSync(true, (txn) {
+    col.isar.getTxnSync(false, (txn) {
       final rawObjPtr = txn.allocRawObject();
       nCall(IC.isar_link_get_first(
           col.ptr, txn.ptr, linkIndex, isBacklink, containingId, rawObjPtr));


### PR DESCRIPTION
Contrary to the sync method, the async load method does not need a write transaction. It also seems to perfectly work when you use a simple read transaction, so I think it's a copy-paste error.