### PR TITLE
feat: save links by default when putting an object

### DIFF
--- a/packages/isar/lib/src/common/isar_link_common.dart
+++ b/packages/isar/lib/src/common/isar_link_common.dart
@@ -45,8 +45,13 @@ abstract class IsarLinkCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
 
   var _isChanged = false;
 
+  var _isLoaded = false;
+
   @override
   bool get isChanged => _isChanged;
+
+  @override
+  bool get isLoaded => _isLoaded;
 
   @override
   OBJ? get value => _value;
@@ -60,6 +65,7 @@ abstract class IsarLinkCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   void applyLoaded(OBJ? object) {
     _value = object;
     _isChanged = false;
+    _isLoaded = true;
   }
 
   void applySaved(OBJ? object) {
@@ -72,6 +78,7 @@ abstract class IsarLinkCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   void resetContent() {
     _value = null;
     _isChanged = false;
+    _isLoaded = true;
   }
 }
 
@@ -82,14 +89,20 @@ abstract class IsarLinksCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   final addedObjects = HashSet<OBJ>.identity();
   final removedObjects = HashSet<OBJ>.identity();
 
+  var _isLoaded = false;
+
   @override
   bool get isChanged => addedObjects.isNotEmpty || removedObjects.isNotEmpty;
+
+  @override
+  bool get isLoaded => _isLoaded;
 
   void applyLoaded(List<OBJ> objects) {
     _objects.clear();
     _objects.addAll(objects);
     _objects.addAll(addedObjects);
     _objects.removeAll(removedObjects);
+    _isLoaded = true;
   }
 
   void applySaved(List<OBJ> added, List<OBJ> removed) {
@@ -106,6 +119,7 @@ abstract class IsarLinksCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   void resetContent() {
     clearChanges();
     _objects.clear();
+    _isLoaded = true;
   }
 
   @override

--- a/packages/isar/lib/src/common/isar_link_common.dart
+++ b/packages/isar/lib/src/common/isar_link_common.dart
@@ -60,6 +60,7 @@ abstract class IsarLinkCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   set value(OBJ? value) {
     _isChanged |= !identical(_value, value);
     _value = value;
+    _isLoaded = true;
   }
 
   void applyLoaded(OBJ? object) {
@@ -72,6 +73,7 @@ abstract class IsarLinkCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
     if (identical(value, object)) {
       _isChanged = false;
     }
+    _isLoaded = true;
   }
 
   @override
@@ -108,6 +110,7 @@ abstract class IsarLinksCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   void applySaved(List<OBJ> added, List<OBJ> removed) {
     addedObjects.removeAll(added);
     removedObjects.removeAll(removed);
+    _isLoaded = true;
   }
 
   void clearChanges() {

--- a/packages/isar/lib/src/isar_collection.dart
+++ b/packages/isar/lib/src/isar_collection.dart
@@ -39,28 +39,28 @@ abstract class IsarCollection<OBJ> {
   Future<int> put(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   });
 
   /// Insert or update an [object] and returns the assigned id.
   int putSync(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   });
 
   /// Insert or update a list of [objects] and returns the list of assigned ids.
   Future<List<int>> putAll(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   });
 
   /// Insert or update a list of [objects] and returns the list of assigned ids.
   List<int> putAllSync(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   });
 
   /// Delete a single object by its [id].

--- a/packages/isar/lib/src/isar_link.dart
+++ b/packages/isar/lib/src/isar_link.dart
@@ -9,6 +9,9 @@ abstract class IsarLinkBase<OBJ> {
   /// Have the contents been changed? If not, `.save()` is a no-op.
   bool get isChanged;
 
+  /// Is the containing object have been loaded?
+  bool get isLoaded;
+
   /// Loads the linked object(s) from the databse
   Future<void> load();
 

--- a/packages/isar/lib/src/native/isar_collection_impl.dart
+++ b/packages/isar/lib/src/native/isar_collection_impl.dart
@@ -210,7 +210,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   Future<int> put(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return putAll(
       [object],
@@ -222,7 +222,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   Future<List<int>> putAll(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return isar.getTxn(true, (txn) async {
       final rawObjSetPtr = txn.allocRawObjSet(objects.length);
@@ -251,9 +251,11 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
 
         if (getLinks != null) {
           adapter.attachLinks(isar, id, object);
-          for (var link in getLinks!(object)) {
-            if (link.isChanged) {
-              linkFutures.add(link.save());
+          if (saveLinks) {
+            for (var link in getLinks!(object)) {
+              if (link.isChanged) {
+                linkFutures.add(link.save());
+              }
             }
           }
         }
@@ -269,7 +271,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   int putSync(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return putAllSync(
       [object],
@@ -282,7 +284,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   List<int> putAllSync(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return isar.getTxnSync(true, (txn) {
       final rawObjPtr = txn.allocRawObject();

--- a/packages/isar/lib/src/native/isar_link_impl.dart
+++ b/packages/isar/lib/src/native/isar_link_impl.dart
@@ -15,7 +15,7 @@ mixin IsarBaseMixin<OBJ> on IsarLinkBaseImpl<OBJ> {
   IsarCollectionImpl<OBJ> get targetCol =>
       super.targetCol as IsarCollectionImpl<OBJ>;
 
-  int get linkIndex => col.linkIds[linkName]!;
+  int get linkIndex => isBacklink ? col.backlinkIds[linkName]! : col.linkIds[linkName]!;
 
   @override
   Future<void> reset() async {

--- a/packages/isar/lib/src/web/isar_collection_impl.dart
+++ b/packages/isar/lib/src/web/isar_collection_impl.dart
@@ -102,7 +102,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   Future<int> put(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return isar.getTxn(true, (txn) async {
       final serialized = adapter.serialize(this, object);
@@ -132,7 +132,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   Future<List<int>> putAll(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return isar.getTxn(true, (txn) async {
       final serialized = [];
@@ -171,7 +171,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   int putSync(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) =>
       unsupportedOnWeb();
 
@@ -179,7 +179,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   List<int> putAllSync(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) =>
       unsupportedOnWeb();
 


### PR DESCRIPTION
This PR modify the API to enable the saveLinks option by default. This has 2 advantages:
- It allows to create a big object hierarchy (with links inside linked objects) and save everything with a single `put(topObject)`. When it was not the default, doing  `put(topObject, saveLinks: true)` was not enough due to the fact it was only saving the top-level links (the `link.save()` method was putting sub-objects with `saveLinks: false`).
- I find quite logical and instinctive that putting an object also puts sub-objects by default if they need to. It is way more user-friendly and does not have any performance impact (links will need to be saved one day anyway, and you can still disable it if you really want).

This PR also contains two fixes:
- the `saveLinks` attribute was actually ignored in the `put`/`putAll` method (contrary to `putSync`/`putAllSync`).
- a small fix for #296 with the `linkIndex` modification. I initially wanted to do 2 separated PRs but I did a wrong manipulation and it has put all commits in the same PR, sorry for that. If there is any issue with that PR I'll open a new one for the #296 fix.