### PR TITLE
feat: save links by default when putting an object

### DIFF
--- a/packages/isar/lib/src/isar_collection.dart
+++ b/packages/isar/lib/src/isar_collection.dart
@@ -39,28 +39,28 @@ abstract class IsarCollection<OBJ> {
   Future<int> put(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   });
 
   /// Insert or update an [object] and returns the assigned id.
   int putSync(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   });
 
   /// Insert or update a list of [objects] and returns the list of assigned ids.
   Future<List<int>> putAll(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   });
 
   /// Insert or update a list of [objects] and returns the list of assigned ids.
   List<int> putAllSync(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   });
 
   /// Delete a single object by its [id].

--- a/packages/isar/lib/src/native/isar_collection_impl.dart
+++ b/packages/isar/lib/src/native/isar_collection_impl.dart
@@ -210,7 +210,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   Future<int> put(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return putAll(
       [object],
@@ -222,7 +222,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   Future<List<int>> putAll(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return isar.getTxn(true, (txn) async {
       final rawObjSetPtr = txn.allocRawObjSet(objects.length);
@@ -251,9 +251,11 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
 
         if (getLinks != null) {
           adapter.attachLinks(isar, id, object);
-          for (var link in getLinks!(object)) {
-            if (link.isChanged) {
-              linkFutures.add(link.save());
+          if (saveLinks) {
+            for (var link in getLinks!(object)) {
+              if (link.isChanged) {
+                linkFutures.add(link.save());
+              }
             }
           }
         }
@@ -269,7 +271,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   int putSync(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return putAllSync(
       [object],
@@ -282,7 +284,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   List<int> putAllSync(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return isar.getTxnSync(true, (txn) {
       final rawObjPtr = txn.allocRawObject();

--- a/packages/isar/lib/src/web/isar_collection_impl.dart
+++ b/packages/isar/lib/src/web/isar_collection_impl.dart
@@ -102,7 +102,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   Future<int> put(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return isar.getTxn(true, (txn) async {
       final serialized = adapter.serialize(this, object);
@@ -132,7 +132,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   Future<List<int>> putAll(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) {
     return isar.getTxn(true, (txn) async {
       final serialized = [];
@@ -171,7 +171,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   int putSync(
     OBJ object, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) =>
       unsupportedOnWeb();
 
@@ -179,7 +179,7 @@ class IsarCollectionImpl<OBJ> extends IsarCollection<OBJ> {
   List<int> putAllSync(
     List<OBJ> objects, {
     bool replaceOnConflict = false,
-    bool saveLinks = false,
+    bool saveLinks = true,
   }) =>
       unsupportedOnWeb();
 


### PR DESCRIPTION
This PR modify the API to enable the saveLinks option by default. This has 2 advantages:
- It allows to create a big object hierarchy (with links inside linked objects) and save everything with a single `put(topObject)`. When it was not the default, doing `put(topObject, saveLinks: true)` was not enough due to the fact it was only saving the top-level links (the `link.save()` method was putting sub-objects with `saveLinks: false`).
- I find quite logical and instinctive that putting an object also puts sub-objects by default if they need to. It is way more user-friendly and does not have any performance impact (links will need to be saved one day anyway, and you can still disable it if you really want).

This PR also fixes one issue: the saveLinks attribute was actually ignored in the put/putAll method (contrary to putSync/putAllSync).