### PR TITLE
feat: allow to know if a link is loaded

### DIFF
--- a/packages/isar/lib/src/common/isar_link_common.dart
+++ b/packages/isar/lib/src/common/isar_link_common.dart
@@ -45,8 +45,13 @@ abstract class IsarLinkCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
 
   var _isChanged = false;
 
+  var _isLoaded = false;
+
   @override
   bool get isChanged => _isChanged;
+
+  @override
+  bool get isLoaded => _isLoaded;
 
   @override
   OBJ? get value => _value;
@@ -60,6 +65,7 @@ abstract class IsarLinkCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   void applyLoaded(OBJ? object) {
     _value = object;
     _isChanged = false;
+    _isLoaded = true;
   }
 
   void applySaved(OBJ? object) {
@@ -72,6 +78,7 @@ abstract class IsarLinkCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   void resetContent() {
     _value = null;
     _isChanged = false;
+    _isLoaded = true;
   }
 }
 
@@ -82,14 +89,20 @@ abstract class IsarLinksCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   final addedObjects = HashSet<OBJ>.identity();
   final removedObjects = HashSet<OBJ>.identity();
 
+  var _isLoaded = false;
+
   @override
   bool get isChanged => addedObjects.isNotEmpty || removedObjects.isNotEmpty;
+
+  @override
+  bool get isLoaded => _isLoaded;
 
   void applyLoaded(List<OBJ> objects) {
     _objects.clear();
     _objects.addAll(objects);
     _objects.addAll(addedObjects);
     _objects.removeAll(removedObjects);
+    _isLoaded = true;
   }
 
   void applySaved(List<OBJ> added, List<OBJ> removed) {
@@ -106,6 +119,7 @@ abstract class IsarLinksCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   void resetContent() {
     clearChanges();
     _objects.clear();
+    _isLoaded = true;
   }
 
   @override

--- a/packages/isar/lib/src/common/isar_link_common.dart
+++ b/packages/isar/lib/src/common/isar_link_common.dart
@@ -60,6 +60,7 @@ abstract class IsarLinkCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   set value(OBJ? value) {
     _isChanged |= !identical(_value, value);
     _value = value;
+    _isLoaded = true;
   }
 
   void applyLoaded(OBJ? object) {
@@ -72,6 +73,7 @@ abstract class IsarLinkCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
     if (identical(value, object)) {
       _isChanged = false;
     }
+    _isLoaded = true;
   }
 
   @override
@@ -108,6 +110,7 @@ abstract class IsarLinksCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   void applySaved(List<OBJ> added, List<OBJ> removed) {
     addedObjects.removeAll(added);
     removedObjects.removeAll(removed);
+    _isLoaded = true;
   }
 
   void clearChanges() {

--- a/packages/isar/lib/src/isar_link.dart
+++ b/packages/isar/lib/src/isar_link.dart
@@ -9,6 +9,9 @@ abstract class IsarLinkBase<OBJ> {
   /// Have the contents been changed? If not, `.save()` is a no-op.
   bool get isChanged;
 
+  /// Is the containing object have been loaded?
+  bool get isLoaded;
+
   /// Loads the linked object(s) from the databse
   Future<void> load();
 


### PR DESCRIPTION
Today there is no way to differenciate a IsarLink/IsarLinks with null/empty value from a non-loaded link. This PR adds a `isLoaded` attribute so that we can check if we need to load the link or if it's value is really null/empty.

I personnally need it because I have done a getter which automatically load the link when I access the attribute (it helps me in my DB migration to isar, because I don't have to rework the app to load all links manually).