### PR TITLE
fix: saveSync method was not working correctly

### DIFF
--- a/packages/isar/lib/src/isar_link.dart
+++ b/packages/isar/lib/src/isar_link.dart
@@ -85,7 +85,7 @@ abstract class IsarLinks<OBJ> implements IsarLinkBase<OBJ>, Set<OBJ> {
   /// and it can even be used without loading the link.
   void updateSync({List<OBJ> link = const [], List<OBJ> unlink = const []});
 
-  /// Starty a query for linked objects.
+  /// Starts a query for linked objects.
   QueryBuilder<OBJ, OBJ, QAfterFilterCondition> filter();
 
   /// Counts the linked objects in the database.

--- a/packages/isar/lib/src/native/isar_link_impl.dart
+++ b/packages/isar/lib/src/native/isar_link_impl.dart
@@ -43,14 +43,15 @@ mixin IsarLinkBaseMixin<OBJ> on IsarLinkBaseImpl<OBJ> {
     final containingId = requireAttached();
     final sourceCol = sourceCollection;
     sourceCol.isar.getTxnSync(true, (txn) {
-      for (var linkId in linkIds) {
-        nCall(IC.isar_link(
-            sourceCol.ptr, txn.ptr, linkIndex, containingId, linkId));
-      }
-      for (var unlinkId in linkIds) {
-        nCall(IC.isar_link_unlink(
-            sourceCol.ptr, txn.ptr, linkIndex, containingId, unlinkId));
-      }
+      final count = linkIds.length + unlinkIds.length;
+      final idsPtr = txn.alloc<Int64>(count);
+      final ids = idsPtr.asTypedList(count);
+
+      ids.setAll(0, linkIds);
+      ids.setAll(linkIds.length, unlinkIds);
+
+      IC.isar_link_update_all(sourceCollection.ptr, txn.ptr, linkIndex,
+          containingId, idsPtr, linkIds.length, unlinkIds.length, reset);
     });
   }
 }


### PR DESCRIPTION
Since I switched to Isar 2.4.0, I noticed some some part of my code (sill using the sync method), were not loading links anymore. When I looked at Isar's code, I noticed a different implementation between the async and sync method. Here is an attempt to fix the sync behavior.