### PR TITLE
bugfix: Fix for link resetSync

### DIFF
--- a/packages/isar/lib/src/common/isar_link_common.dart
+++ b/packages/isar/lib/src/common/isar_link_common.dart
@@ -160,7 +160,7 @@ abstract class IsarLinkCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
 
   @override
   void resetSync() {
-    updateNative([], [], true);
+    updateNativeSync([], [], true);
     _value = null;
     _isChanged = false;
     _isLoaded = true;


### PR DESCRIPTION
Calling `resetSync()` on an `IsarLink` inside a `writeTxnSync`  used to throw `IsarError: Write operations require an explicit transaction.`.
