### PR TITLE
Implemented index tests

### DIFF
--- a/packages/isar_test/test/index_test.dart
+++ b/packages/isar_test/test/index_test.dart
@@ -1,1 +1,0 @@
-void main() {}

--- a/packages/isar_test/test/index_type_hash_elements_test.dart
+++ b/packages/isar_test/test/index_type_hash_elements_test.dart
@@ -1,0 +1,151 @@
+import 'package:isar/isar.dart';
+import 'package:test/test.dart';
+
+import 'util/common.dart';
+import 'util/sync_async_helper.dart';
+
+part 'index_type_hash_elements_test.g.dart';
+
+@Collection()
+class HashElementsIndexesModel {
+  int? id;
+
+  @Index(type: IndexType.hashElements, caseSensitive: true)
+  List<String> stringListSensitiveIndex;
+
+  @Index(type: IndexType.hashElements, caseSensitive: false)
+  List<String> stringListInsensitiveIndex;
+
+  HashElementsIndexesModel({
+    required this.stringListSensitiveIndex,
+    required this.stringListInsensitiveIndex,
+  });
+
+  @override
+  bool operator ==(dynamic other) {
+    return other is HashElementsIndexesModel &&
+        listEquals(stringListSensitiveIndex, other.stringListSensitiveIndex) &&
+        listEquals(
+            stringListInsensitiveIndex, other.stringListInsensitiveIndex);
+  }
+
+  @override
+  String toString() {
+    return 'HashElementsIndexModel{stringListSensitiveIndex: $stringListSensitiveIndex, stringListInsensitiveIndex: $stringListInsensitiveIndex}';
+  }
+}
+
+void main() {
+  testSyncAsync(tests);
+}
+
+void tests() {
+  group("Index hash elements type", () {
+    late Isar isar;
+
+    late HashElementsIndexesModel model0;
+    late HashElementsIndexesModel model1;
+    late HashElementsIndexesModel model2;
+    late HashElementsIndexesModel model3;
+    late HashElementsIndexesModel model4;
+
+    setUp(() async {
+      isar = await openTempIsar([HashElementsIndexesModelSchema]);
+
+      model0 = HashElementsIndexesModel(
+        stringListSensitiveIndex: ["Foo", "bAR", "", ""],
+        stringListInsensitiveIndex: ["fOo", "BaR"],
+      );
+      model1 = HashElementsIndexesModel(
+        stringListSensitiveIndex: [
+          "Γαζέες καὶ μυρτιὲς δὲν θὰ βρῶ πιὰ στὸ χρυσαφὶ ξέφωτο",
+          "The quick brown fox jumps over the lazy dog",
+          "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム",
+          "Pchnąć w tę łódź jeża lub ośm skrzyń fig",
+          "В чащах юга жил бы цитрус? Да, но фальшивый экземпляр!",
+        ],
+        stringListInsensitiveIndex: ["FoO", "bAr"],
+      );
+      model2 = HashElementsIndexesModel(
+        stringListSensitiveIndex: [],
+        stringListInsensitiveIndex: [],
+      );
+      model3 = HashElementsIndexesModel(
+        stringListSensitiveIndex: [
+          "Pijamalı hasta, yağız şoföre çabucak güvendi.",
+          "0",
+          "\u0000",
+          "Δ",
+          "͌",
+          "⋮",
+        ],
+        stringListInsensitiveIndex: ["BaR", "fOo"],
+      );
+      model4 = HashElementsIndexesModel(
+        stringListSensitiveIndex: ["\u0000", "0"],
+        stringListInsensitiveIndex: ["0", "\u0000"],
+      );
+
+      await isar.tWriteTxn(() async {
+        await isar.hashElementsIndexesModels.tPutAll([
+          model0,
+          model1,
+          model2,
+          model3,
+          model4,
+        ]);
+      });
+    });
+
+    tearDown(() => isar.close());
+
+    isarTest("Query List<String> sensitive index", () async {
+      final result1 = await isar.hashElementsIndexesModels
+          .where()
+          .stringListSensitiveIndexAnyEqualTo("Foo")
+          .tFindAll();
+      expect(result1, [model0]);
+
+      final result2 = await isar.hashElementsIndexesModels
+          .where()
+          .stringListSensitiveIndexAnyEqualTo("")
+          .tFindAll();
+      expect(result2, [model0]);
+
+      final result3 = await isar.hashElementsIndexesModels
+          .where()
+          .anyStringListSensitiveIndexAny()
+          .tFindAll();
+      expect(result3, {model0, model1, model3, model4});
+
+      // FIXME: The null character ("\u0000") causes issues in the index.
+      // Works with other characters
+      // final result4 = await isar.hashElementsIndexesModels
+      //     .where()
+      //     .stringListSensitiveIndexAnyEqualTo("\u0000")
+      //     .tFindAll();
+      // expect(result4, {model3, model4});
+    });
+
+    isarTest("Query List<String> insensitive index", () async {
+      final result1 = await isar.hashElementsIndexesModels
+          .where()
+          .stringListInsensitiveIndexAnyEqualTo("bar")
+          .tFindAll();
+      expect(result1, {model0, model1, model3});
+
+      final result2 = await isar.hashElementsIndexesModels
+          .where()
+          .stringListInsensitiveIndexAnyEqualTo("")
+          .tFindAll();
+      expect(result2, <HashElementsIndexesModel>[]);
+
+      // FIXME: null character
+      // final result3 = await isar.hashElementsIndexesModels
+      //     .where()
+      //    .stringListInsensitiveIndexAnyEqualTo("\u0000")
+      //    .tFindAll();
+      // expect(result3, [model4]);
+    });
+  });
+}

--- a/packages/isar_test/test/index_type_hash_test.dart
+++ b/packages/isar_test/test/index_type_hash_test.dart
@@ -1,0 +1,190 @@
+import 'package:isar/isar.dart';
+import 'package:test/test.dart';
+
+import 'util/common.dart';
+import 'util/sync_async_helper.dart';
+
+part 'index_type_hash_test.g.dart';
+
+@Collection()
+class HashIndexesModel {
+  int? id;
+
+  @Index(type: IndexType.hash, caseSensitive: true)
+  String stringSensitiveIndex;
+
+  @Index(type: IndexType.hash, caseSensitive: false)
+  String stringInsensitiveIndex;
+
+  @Index(type: IndexType.hash)
+  List<bool> boolListIndex;
+
+  @Index(type: IndexType.hash)
+  List<int> intListIndex;
+
+  @Index(type: IndexType.hash)
+  List<DateTime> dateTimeListIndex;
+
+  @Index(type: IndexType.hash, caseSensitive: true)
+  List<String> stringListSensitiveIndex;
+
+  @Index(type: IndexType.hash, caseSensitive: false)
+  List<String> stringListInsensitiveIndex;
+
+  HashIndexesModel({
+    required this.stringSensitiveIndex,
+    required this.stringInsensitiveIndex,
+    required this.boolListIndex,
+    required this.intListIndex,
+    required this.dateTimeListIndex,
+    required this.stringListSensitiveIndex,
+    required this.stringListInsensitiveIndex,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is HashIndexesModel &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          stringSensitiveIndex == other.stringSensitiveIndex &&
+          stringInsensitiveIndex == other.stringInsensitiveIndex &&
+          listEquals(boolListIndex, other.boolListIndex) &&
+          listEquals(intListIndex, other.intListIndex) &&
+          listEquals(dateTimeListIndex, other.dateTimeListIndex) &&
+          listEquals(
+              stringListSensitiveIndex, other.stringListSensitiveIndex) &&
+          listEquals(
+              stringListInsensitiveIndex, other.stringListInsensitiveIndex);
+
+  @override
+  String toString() {
+    return 'HashIndexesModel{stringSensitiveIndex: $stringSensitiveIndex, stringInsensitiveIndex: $stringInsensitiveIndex, boolListIndex: $boolListIndex, intListIndex: $intListIndex, dateTimeListIndex: $dateTimeListIndex, stringListSensitiveIndex: $stringListSensitiveIndex, stringListInsensitiveIndex: $stringListInsensitiveIndex}';
+  }
+}
+
+void main() {
+  testSyncAsync(tests);
+}
+
+void tests() {
+  group("Index hash type", () {
+    late Isar isar;
+    late HashIndexesModel model0;
+    late HashIndexesModel model1;
+
+    setUp(() async {
+      isar = await openTempIsar([HashIndexesModelSchema]);
+
+      await isar.tWriteTxn(() async {
+        model0 = HashIndexesModel(
+          stringSensitiveIndex: "My index",
+          stringInsensitiveIndex: "John Smith",
+          boolListIndex: [true, true, false],
+          intListIndex: [1, 99, 42],
+          dateTimeListIndex: [DateTime(2001, 4, 4), DateTime(1995, 7, 27)],
+          stringListSensitiveIndex: ["FOO"],
+          stringListInsensitiveIndex: ["loREM", "IPSum"],
+        );
+        model1 = HashIndexesModel(
+          stringSensitiveIndex: "mY INDEX",
+          stringInsensitiveIndex: "jOHN SMiTh",
+          boolListIndex: List.filled(100, true),
+          intListIndex: [6, -5],
+          dateTimeListIndex: [DateTime(1992, 1, 24)],
+          stringListSensitiveIndex: ["foo", "bar"],
+          stringListInsensitiveIndex: ["LORem", "ipsum"],
+        );
+        await isar.hashIndexesModels.tPutAll([model0, model1]);
+      });
+    });
+
+    tearDown(() => isar.close());
+
+    isarTest("Query String sensitive index", () async {
+      final result = await isar.hashIndexesModels
+          .where()
+          .stringSensitiveIndexNotEqualTo("mY INDEX")
+          .tFindAll();
+      expect(result, [model0]);
+    });
+
+    isarTest("Query String insensitive index", () async {
+      final result1 = await isar.hashIndexesModels
+          .where()
+          .stringInsensitiveIndexEqualTo("john smith")
+          .tFindAll();
+      expect(result1, {model0, model1});
+
+      final result2 = await isar.hashIndexesModels
+          .where()
+          .stringInsensitiveIndexEqualTo("john doe")
+          .tFindAll();
+      expect(result2, <HashIndexesModel>[]);
+    });
+
+    isarTest("Query List<bool> index", () async {
+      final result = await isar.hashIndexesModels
+          .where()
+          .boolListIndexEqualTo([true, true, false]).findAll();
+      expect(result, [model0]);
+    });
+
+    isarTest("query List<int> index", () async {
+      final result = await isar.hashIndexesModels
+          .where()
+          .intListIndexNotEqualTo([6, -5]).tFindAll();
+      expect(result, [model0]);
+    });
+
+    // FIXME: type issue with List<DateTime> hash
+    // type 'MappedListIterable<DateTime, int?>' is not a subtype of type 'List<int?>' in type cast
+    // isarTest("Query List<DateTime> index", () async {
+    //   final result = await isar.hashIndexesModels
+    //       .where()
+    //       .dateTimeListIndexEqualTo([DateTime(1992, 1, 24)]).tFindAll();
+    //   expect(result, [model1]);
+    // });
+
+    isarTest("Query List<String> sensitive index", () async {
+      final result = await isar.hashIndexesModels
+          .where()
+          .stringListSensitiveIndexEqualTo([]).tFindAll();
+      expect(result, <HashIndexesModel>[]);
+    });
+
+    isarTest("Query List<String> insensitive index", () async {
+      final result1 = await isar.hashIndexesModels
+          .where()
+          .stringListInsensitiveIndexEqualTo(["lorem", "IPSUM"]).tFindAll();
+      expect(result1, {model0, model1});
+
+      final result2 = await isar.hashIndexesModels
+          .where()
+          .stringListInsensitiveIndexEqualTo(["lorem"]).tFindAll();
+      expect(result2, <HashIndexesModel>[]);
+    });
+
+    isarTest("Query every index", () async {
+      final result = await isar.hashIndexesModels
+          .where()
+          .stringSensitiveIndexNotEqualTo("My index")
+          .or()
+          .stringInsensitiveIndexEqualTo("JOHN SMIth")
+          .or()
+          .boolListIndexEqualTo([true, true, false])
+          .or()
+          .intListIndexNotEqualTo([])
+          .or()
+          // FIXME: type issue with List<DateTime> hash
+          // .dateTimeListIndexNotEqualTo([DateTime(1234, 1, 1)])
+          // .or()
+          .stringListSensitiveIndexEqualTo(["foo", "bar"])
+          .or()
+          .stringListInsensitiveIndexEqualTo(["lorem", "ipsum"])
+          .tFindAll();
+      // FIXME: multiple duplicates in result
+      expect(result, {model0, model1});
+    });
+  });
+}

--- a/packages/isar_test/test/index_type_value_test.dart
+++ b/packages/isar_test/test/index_type_value_test.dart
@@ -1,0 +1,298 @@
+import 'package:isar/isar.dart';
+import 'package:test/test.dart';
+
+import 'util/common.dart';
+import 'util/sync_async_helper.dart';
+
+part 'index_type_value_test.g.dart';
+
+@Collection()
+class ValueIndexesModel {
+  int? id;
+
+  @Index(type: IndexType.value)
+  bool boolIndex;
+
+  @Index(type: IndexType.value)
+  int intIndex;
+
+  @Index(type: IndexType.value)
+  double doubleIndex;
+
+  @Index(type: IndexType.value)
+  DateTime dateTimeIndex;
+
+  @Index(type: IndexType.value, caseSensitive: true)
+  String stringIndexSensitive;
+
+  @Index(type: IndexType.value, caseSensitive: false)
+  String stringIndexInsensitive;
+
+  @Index(type: IndexType.value)
+  List<bool> boolListIndex;
+
+  @Index(type: IndexType.value)
+  List<int> intListIndex;
+
+  @Index(type: IndexType.value)
+  List<double> doubleListIndex;
+
+  @Index(type: IndexType.value)
+  List<DateTime> dateTimeListIndex;
+
+  @Index(type: IndexType.value, caseSensitive: true)
+  List<String> stringListSensitiveIndex;
+
+  @Index(type: IndexType.value, caseSensitive: false)
+  List<String> stringListInsensitiveIndex;
+
+  ValueIndexesModel({
+    required this.boolIndex,
+    required this.intIndex,
+    required this.doubleIndex,
+    required this.dateTimeIndex,
+    required this.stringIndexSensitive,
+    required this.stringIndexInsensitive,
+    required this.boolListIndex,
+    required this.intListIndex,
+    required this.doubleListIndex,
+    required this.dateTimeListIndex,
+    required this.stringListSensitiveIndex,
+    required this.stringListInsensitiveIndex,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    return other is ValueIndexesModel &&
+        runtimeType == other.runtimeType &&
+        id == other.id &&
+        boolIndex == other.boolIndex &&
+        intIndex == other.intIndex &&
+        doubleIndex == other.doubleIndex &&
+        dateTimeIndex == other.dateTimeIndex &&
+        stringIndexSensitive == other.stringIndexSensitive &&
+        stringIndexInsensitive == other.stringIndexInsensitive &&
+        listEquals(boolListIndex, boolListIndex) &&
+        listEquals(intListIndex, other.intListIndex) &&
+        listEquals(doubleListIndex, other.doubleListIndex) &&
+        listEquals(dateTimeListIndex, other.dateTimeListIndex) &&
+        listEquals(stringListSensitiveIndex, other.stringListSensitiveIndex) &&
+        listEquals(
+            stringListInsensitiveIndex, other.stringListInsensitiveIndex);
+  }
+
+  @override
+  String toString() {
+    return 'ValueIndexesModel{boolIndex: $boolIndex, intIndex: $intIndex, doubleIndex: $doubleIndex, dateTimeIndex: $dateTimeIndex, stringIndexSensitive: $stringIndexSensitive, stringIndexInsensitive: $stringIndexInsensitive, boolListIndex: $boolListIndex, intListIndex: $intListIndex, doubleListIndex: $doubleListIndex, dateTimeListIndex: $dateTimeListIndex, stringListSensitiveIndex: $stringListSensitiveIndex, stringListInsensitiveIndex: $stringListInsensitiveIndex}';
+  }
+}
+
+void main() {
+  testSyncAsync(tests);
+}
+
+void tests() {
+  group("Index value type", () {
+    late Isar isar;
+    late ValueIndexesModel model0;
+    late ValueIndexesModel model1;
+
+    setUp(() async {
+      isar = await openTempIsar([ValueIndexesModelSchema]);
+
+      await isar.tWriteTxn(() async {
+        model0 = ValueIndexesModel(
+          boolIndex: true,
+          intIndex: 55,
+          doubleIndex: 0.42,
+          dateTimeIndex: DateTime(1950, 1, 13),
+          stringIndexSensitive: "My index",
+          stringIndexInsensitive: "fOo BaR",
+          boolListIndex: [true, true, false],
+          intListIndex: [1, 99, 42],
+          doubleListIndex: [4.32, 8, 44.23, 1509182.1231089124089571209377],
+          dateTimeListIndex: [DateTime(2001, 4, 4), DateTime(1995, 7, 27)],
+          stringListSensitiveIndex: [],
+          stringListInsensitiveIndex: ["Earth"],
+        );
+        model1 = ValueIndexesModel(
+          boolIndex: false,
+          intIndex: -123,
+          doubleIndex: 4432.1,
+          dateTimeIndex: DateTime(2100, 4, 4),
+          stringIndexSensitive: "mY INDEX",
+          stringIndexInsensitive: "FoO bAr",
+          boolListIndex: List.filled(100, true),
+          intListIndex: [6, -5],
+          doubleListIndex: [-4.32, 8, 44, -152.001, -0.0],
+          dateTimeListIndex: [DateTime(1992, 1, 24)],
+          stringListSensitiveIndex: ["foo", "bar"],
+          stringListInsensitiveIndex: ["eArTh"],
+        );
+        await isar.valueIndexesModels.tPutAll([model0, model1]);
+      });
+    });
+
+    tearDown(() => isar.close());
+
+    isarTest("Query bool index", () async {
+      final result = await isar.valueIndexesModels
+          .where()
+          .boolIndexEqualTo(true)
+          .tFindAll();
+      expect(result, [model0]);
+    });
+
+    isarTest("Query int test", () async {
+      final result1 = await isar.valueIndexesModels
+          .where()
+          .intIndexEqualTo(-123)
+          .tFindAll();
+      expect(result1, [model1]);
+
+      final result2 =
+          await isar.valueIndexesModels.where().intIndexEqualTo(-0).tFindAll();
+      expect(result2, <ValueIndexesModel>[]);
+    });
+
+    isarTest("Query double index", () async {
+      final result = await isar.valueIndexesModels
+          .where()
+          .doubleIndexGreaterThan(4432.0999999999999)
+          .tFindAll();
+      expect(result, [model1]);
+    });
+
+    isarTest("query DateTime index", () async {
+      final result = await isar.valueIndexesModels
+          .where()
+          .dateTimeIndexEqualTo(DateTime(2100, 4, 4))
+          .tFindAll();
+      expect(result, [model1]);
+    });
+
+    isarTest("Query String sensitive index", () async {
+      final result1 = await isar.valueIndexesModels
+          .where()
+          .stringIndexSensitiveNotEqualTo("mY INDEX")
+          .tFindAll();
+      expect(result1, [model0]);
+
+      final result2 = await isar.valueIndexesModels
+          .where()
+          .stringIndexSensitiveStartsWith("mY")
+          .tFindAll();
+      expect(result2, [model1]);
+    });
+
+    isarTest("Query String insensitive index", () async {
+      final result1 = await isar.valueIndexesModels
+          .where()
+          .stringIndexInsensitiveEqualTo("foo bar")
+          .tFindAll();
+      expect(result1, {model0, model1});
+
+      final result2 = await isar.valueIndexesModels
+          .where()
+          .stringIndexInsensitiveStartsWith("f")
+          .tFindAll();
+      expect(result2, {model0, model1});
+
+      final result3 = await isar.valueIndexesModels
+          .where()
+          .stringIndexInsensitiveGreaterThan("foo bar")
+          .tFindAll();
+      expect(result3, <ValueIndexesModel>[]);
+    });
+
+    isarTest("Query List<bool> index", () async {
+      final result = await isar.valueIndexesModels
+          .where()
+          .boolListIndexAnyEqualTo(false)
+          .findAll();
+      expect(result, [model0]);
+    });
+
+    isarTest("query List<int> index", () async {
+      final result = await isar.valueIndexesModels
+          .where()
+          .intListIndexAnyGreaterThan(42)
+          .tFindAll();
+      expect(result, [model0]);
+    });
+
+    isarTest("Query List<double> index", () async {
+      final result = await isar.valueIndexesModels
+          .where()
+          .doubleListIndexAnyLessThan(100)
+          .tFindAll();
+      expect(result, {model0, model1});
+    });
+
+    isarTest("Query List<DateTime> index", () async {
+      final result = await isar.valueIndexesModels
+          .where()
+          .dateTimeListIndexAnyLessThan(DateTime(1995, 1, 1))
+          .tFindAll();
+      expect(result, [model1]);
+    });
+
+    isarTest("Query List<String> sensitive index", () async {
+      final result = await isar.valueIndexesModels
+          .where()
+          .stringListSensitiveIndexAnyGreaterThan("d")
+          .tFindAll();
+      expect(result, [model1]);
+    });
+
+    isarTest("Query List<String> insensitive index", () async {
+      final result1 = await isar.valueIndexesModels
+          .where()
+          .stringListInsensitiveIndexAnyEqualTo("earth")
+          .tFindAll();
+      expect(result1, {model0, model1});
+
+      final result2 = await isar.valueIndexesModels
+          .where()
+          .stringListInsensitiveIndexAnyStartsWith("e")
+          .tFindAll();
+      expect(result2, {model0, model1});
+
+      final result3 = await isar.valueIndexesModels
+          .where()
+          .stringListInsensitiveIndexAnyStartsWith("mars")
+          .tFindAll();
+      expect(result3, <ValueIndexesModel>[]);
+    });
+
+    isarTest("Query every index", () async {
+      final result = await isar.valueIndexesModels
+          .where()
+          .boolIndexEqualTo(false)
+          .or()
+          .intIndexLessThan(-120)
+          .or()
+          .doubleIndexBetween(1000, 5000)
+          .or()
+          .dateTimeIndexEqualTo(DateTime(2100, 4, 4))
+          .or()
+          .stringIndexSensitiveNotEqualTo("My index")
+          .or()
+          .stringIndexInsensitiveStartsWith("foo")
+          .or()
+          .boolListIndexAnyNotEqualTo(false)
+          .or()
+          .intListIndexAnyLessThan(0)
+          .or()
+          .doubleListIndexAnyLessThan(-100)
+          .or()
+          .dateTimeListIndexAnyLessThan(DateTime(1995, 1, 1))
+          .or()
+          .stringListSensitiveIndexAnyEqualTo("foo")
+          .or()
+          .stringListInsensitiveIndexAnyStartsWith("e")
+          .tFindAll();
+      expect(result, {model0, model1});
+    });
+  });
+}


### PR DESCRIPTION
I separated the tests in 3 files, one per index type:
- Value
- Hash
- HashElements

I found some issues:

- Hash index with type `List<DateTime>` causes type issues on query
`type 'MappedListIterable<DateTime, int?>' is not a subtype of type 'List<int?>' in type cast`
The issue is in file `isar/src/native/index_key.dart`, where the value is casted to a `List<int?>`.

- Maybe I didn't do it right, but when I query multiple different Hash indexes, the result contains duplicated values (test `Query every index` in file `index_type_hash_test.dart`).

- Extremely minor issue: The null character (`\u0000`) causes issues with HashElements index. If we query for the character (`...AnyEqualsTo("\u0000")`), an object that doesn't match returns, and the one that does doesn't get returned.

- This is more an issue for the generator, but for property of type `List<String>` with HashElements index, methods such as `...AnyStartsWith(...), ...AnyGreaterThan(...)` are generated, which they shouldn't be, since they don't work with hashes. Those methods are not generated for Hash index, only the equality ones are.

Let me know if you want me to create issues for them.