### PR TITLE
updating ffi to 2.0.1 breaks a lot of apps

### DIFF
--- a/packages/isar/pubspec.yaml
+++ b/packages/isar/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  ffi: ^2.0.1
+  ffi: '>=2.0.0 <2.0.1'
   js: ^0.6.4
   meta: ^1.7.0
 

--- a/packages/isar/pubspec.yaml
+++ b/packages/isar/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  ffi: '>=2.0.0 <2.0.1'
+  ffi: '>=2.0.0 <3.0.0'
   js: ^0.6.4
   meta: ^1.7.0
 


### PR DESCRIPTION
ffi: '>=2.0.0 <2.0.1' to accomodate transition period to latest ffi.