### PR TITLE
Refactored composite string index test

### DIFF
--- a/packages/isar/lib/src/version.dart
+++ b/packages/isar/lib/src/version.dart
@@ -2,7 +2,7 @@
 
 import 'dart:math';
 
-const isarCoreVersion = '2.5.28';
+const isarCoreVersion = '2.5.29';
 final isarCoreVersionNumber = _getVersionNumber(isarCoreVersion);
 
 const isarWebVersion = '2.5.1';

--- a/packages/isar_test/test/index/composite_string_test.dart
+++ b/packages/isar_test/test/index/composite_string_test.dart
@@ -103,37 +103,152 @@ void main() {
       );
     });
 
-    // FIXME: Test currently does not pass.
-    isarTest('Sorted by value1 value2', () async {
+    isarTest('Query value1 equalTo and value2 startsWith', () async {
       await qEqual(
-        isar.models.where().sortByValue1().thenByValue2().tFindAll(),
-        [obj2, obj1, obj0, obj4, obj6, obj5, obj3],
-      );
-
-      // FIXME: when there is an empty string (obj2), using `anyValue1Value2()`
-      // to sort values breaks, and for some reasons puts obj in order of
-      // [obj6, obj2, obj3, obj1, obj0, obj4, obj5]. The first 3 are wrong.
-      // The value before and after (coincidence?) the empty string are at the
-      // wrong place.
-      // Replacing the empty string with text fixes the issue.
-      await qEqual(
-        isar.models.where().anyValue1Value2().tFindAll(),
-        [obj2, obj1, obj0, obj4, obj6, obj5, obj3],
+        isar.models
+            .where()
+            .value1EqualToValue2StartsWith('John', 'D')
+            .tFindAll(),
+        [obj5],
       );
     });
 
-    isarTest('Get by value1 sorted by value2', () async {
+    isarTest('Query value1 equalTo and value2 greaterThan', () async {
       await qEqual(
-        isar.models.where().value1EqualToAnyValue2('Foo').tFindAll(),
+        isar.models
+            .where()
+            .value1EqualToValue2GreaterThan('Foo', 'Bar')
+            .tFindAll(),
+        [obj4],
+      );
+
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2GreaterThan('Foo', 'B')
+            .tFindAll(),
+        [obj0, obj4],
+      );
+    });
+
+    isarTest('Query value1 equalTo and value2 notEqualTo', () async {
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2NotEqualTo('Bar', 'Bar')
+            .tFindAll(),
+        [obj1],
+      );
+
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2NotEqualTo('Foo', 'Bar')
+            .tFindAll(),
+        [obj4],
+      );
+    });
+
+    isarTest('Query value1 equalTo and value2 lessThan', () async {
+      await qEqual(
+        isar.models.where().value1EqualToValue2LessThan('', 'D').tFindAll(),
+        [obj2],
+      );
+
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2LessThan('Foo', 'bar')
+            .tFindAll(),
+        [obj0, obj4],
+      );
+    });
+
+    isarTest('Query value1 equalTo and value2 between', () async {
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2Between(
+              'Foo',
+              'AAAAAAaAAaaAAaAAaAAaaA',
+              'zZZzzZZzzZzzZZzzZzzZZzZZzzzz',
+            )
+            .tFindAll(),
         [obj0, obj4],
       );
 
-      // FIXME: Weird value order
-      // Seems to be sorted according to value1 and encountering empty string
-      // sort bug
       await qEqual(
-        isar.models.where().value1NotEqualToAnyValue2('Foo').tFindAll(),
-        [obj2, obj5, obj6, obj1, obj3],
+        isar.models
+            .where()
+            .value1EqualToValue2Between('John', 'Z', 'A')
+            .tFindAll(),
+        [],
+      );
+
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2Between('John', 'A', 'Z')
+            .tFindAll(),
+        [obj5],
+      );
+    });
+
+    isarTest('anyOf value1 equalTo and any value2', () async {
+      await qEqual(
+        isar.models.where().anyOf<String, Model>(
+          ['Foo', 'John'],
+          (q, element) => q.value1EqualToAnyValue2(element),
+        ).tFindAll(),
+        [obj0, obj4, obj5],
+      );
+    });
+
+    isarTest('Multiple where queries', () async {
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToAnyValue2('aoeu')
+            .or()
+            .value1EqualToAnyValue2('Bar')
+            .or()
+            .value1EqualToValue2GreaterThan('Foo', 'Isar')
+            .tFindAll(),
+        [obj3, obj1, obj4],
+      );
+
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToAnyValue2('aoeu')
+            .or()
+            .value1EqualToValue2StartsWith('Foo', 'Not')
+            .tFindAll(),
+        [obj3, obj4],
+      );
+
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2StartsWith('aoeu', 'A')
+            .or()
+            .value1EqualToValue2StartsWith('Foo', 'Ba')
+            .or()
+            .value1EqualToValue2StartsWith('Foo', 'Not ')
+            .tFindAll(),
+        [obj0, obj4],
+      );
+
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2GreaterThan('Foo', 'A')
+            .or()
+            .value1EqualToValue2LessThan('Jane', 'dOE')
+            .or()
+            .value1EqualToValue2NotEqualTo('', '')
+            .tFindAll(),
+        [obj0, obj4, obj6, obj2],
       );
     });
 

--- a/packages/isar_test/test/index/composite_string_test.dart
+++ b/packages/isar_test/test/index/composite_string_test.dart
@@ -67,7 +67,7 @@ void main() {
       );
     });
 
-    isarTest('Query by value1 and value2', () async {
+    isarTest('Query value1 equalTo and value2 equalTo', () async {
       await qEqual(
         isar.models.where().value1Value2EqualTo('Foo', 'Bar').tFindAll(),
         [obj0],
@@ -103,6 +103,24 @@ void main() {
       );
     });
 
+    isarTest('Query value1 equalTo and value notEqualTo', () async {
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2NotEqualTo('Foo', 'Not bar')
+            .tFindAll(),
+        [obj0],
+      );
+
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2NotEqualTo('unknown', 'value')
+            .tFindAll(),
+        [],
+      );
+    });
+
     isarTest('Query value1 equalTo and value2 startsWith', () async {
       await qEqual(
         isar.models
@@ -110,6 +128,27 @@ void main() {
             .value1EqualToValue2StartsWith('John', 'D')
             .tFindAll(),
         [obj5],
+      );
+
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2StartsWith('John', 'd')
+            .tFindAll(),
+        [],
+      );
+
+      await qEqual(
+        isar.models.where().value1EqualToValue2StartsWith('Foo', '').tFindAll(),
+        [obj0, obj4],
+      );
+
+      await qEqual(
+        isar.models
+            .where()
+            .value1EqualToValue2StartsWith('Foo', 'Bar')
+            .tFindAll(),
+        [obj0],
       );
     });
 

--- a/packages/isar_test/test/util/common.dart
+++ b/packages/isar_test/test/util/common.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:isar/isar.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
@@ -46,6 +47,9 @@ Future<void> _prepareTest() async {
     try {
       await Isar.initializeIsarCore(download: true);
     } catch (e) {
+      if (kDebugMode) {
+        print('Could not initialize isar core: $e');
+      }
       // ignore. maybe this is an instrumentation test
     }
   }


### PR DESCRIPTION
I changed the `isarCodeVersion` to '2.5.29', since I was getting 404's with version '2.5.28'. Feel to let me know if it should be '2.5.28'.

I refactored the composite string index test and added more test based on strings (startsWith, greaterThan, lessThan, between)