### PR TITLE
Implemented more converter tests

### DIFF
--- a/packages/isar/lib/src/version.dart
+++ b/packages/isar/lib/src/version.dart
@@ -2,7 +2,7 @@
 
 import 'dart:math';
 
-const isarCoreVersion = '2.5.28';
+const isarCoreVersion = '2.5.29';
 final isarCoreVersionNumber = _getVersionNumber(isarCoreVersion);
 
 const isarWebVersion = '2.5.1';

--- a/packages/isar_test/test/converter/bool_converter_test.dart
+++ b/packages/isar_test/test/converter/bool_converter_test.dart
@@ -1,0 +1,330 @@
+import 'package:collection/collection.dart' show IterableExtension;
+import 'package:isar/isar.dart';
+import 'package:test/test.dart';
+
+import '../util/common.dart';
+import '../util/sync_async_helper.dart';
+
+part 'bool_converter_test.g.dart';
+
+@Collection()
+class BoolModel {
+  BoolModel({
+    required this.boolEnum,
+    required this.maybeBoolEnum,
+    required this.indexedBoolEnum,
+  });
+
+  int id = Isar.autoIncrement;
+
+  @MyBoolEnumTypeConverter()
+  final MyBoolEnum boolEnum;
+
+  @NullableMyBoolEnumTypeConverter()
+  final MyBoolEnum? maybeBoolEnum;
+
+  @Index()
+  @MyBoolEnumTypeConverter()
+  final MyBoolEnum indexedBoolEnum;
+
+  @override
+  // ignore: hash_and_equals
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BoolModel &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          boolEnum == other.boolEnum &&
+          maybeBoolEnum == other.maybeBoolEnum &&
+          indexedBoolEnum == other.indexedBoolEnum;
+
+  @override
+  String toString() {
+    return 'BoolModel{id: $id, boolEnum: $boolEnum, maybeBoolEnum: $maybeBoolEnum, indexedBoolEnum: $indexedBoolEnum}';
+  }
+}
+
+@Collection(inheritance: true)
+class ChildBoolModel extends BoolModel {
+  ChildBoolModel({
+    required super.boolEnum,
+    required super.maybeBoolEnum,
+    required super.indexedBoolEnum,
+    required this.doubleNegatedBool,
+  });
+
+  @BoolNegatorTypeConverter()
+  final bool doubleNegatedBool;
+
+  @override
+  // ignore: hash_and_equals
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ChildBoolModel &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          boolEnum == other.boolEnum &&
+          maybeBoolEnum == other.maybeBoolEnum &&
+          indexedBoolEnum == other.indexedBoolEnum &&
+          doubleNegatedBool == other.doubleNegatedBool;
+}
+
+enum MyBoolEnum {
+  yes(true),
+  no(false);
+
+  const MyBoolEnum(this.value);
+
+  final bool value;
+}
+
+class MyBoolEnumTypeConverter extends TypeConverter<MyBoolEnum, bool> {
+  const MyBoolEnumTypeConverter();
+
+  @override
+  MyBoolEnum fromIsar(bool value) {
+    return MyBoolEnum.values.firstWhere((element) => element.value == value);
+  }
+
+  @override
+  bool toIsar(MyBoolEnum element) => element.value;
+}
+
+class NullableMyBoolEnumTypeConverter
+    extends TypeConverter<MyBoolEnum?, bool?> {
+  const NullableMyBoolEnumTypeConverter();
+
+  @override
+  MyBoolEnum? fromIsar(bool? value) {
+    return MyBoolEnum.values.firstWhereOrNull(
+      (element) => element.value == value,
+    );
+  }
+
+  @override
+  bool? toIsar(MyBoolEnum? element) => element?.value;
+}
+
+class BoolNegatorTypeConverter extends TypeConverter<bool, bool> {
+  const BoolNegatorTypeConverter();
+
+  @override
+  bool fromIsar(bool value) => !value;
+
+  @override
+  bool toIsar(bool value) => !value;
+}
+
+void main() {
+  group('Bool converter', () {
+    late Isar isar;
+
+    late BoolModel obj0;
+    late BoolModel obj1;
+    late BoolModel obj2;
+    late ChildBoolModel childObj0;
+    late ChildBoolModel childObj1;
+    late ChildBoolModel childObj2;
+
+    setUp(() async {
+      isar = await openTempIsar([BoolModelSchema, ChildBoolModelSchema]);
+
+      obj0 = BoolModel(
+        boolEnum: MyBoolEnum.no,
+        maybeBoolEnum: null,
+        indexedBoolEnum: MyBoolEnum.no,
+      );
+      obj1 = BoolModel(
+        boolEnum: MyBoolEnum.yes,
+        maybeBoolEnum: MyBoolEnum.yes,
+        indexedBoolEnum: MyBoolEnum.no,
+      );
+      obj2 = BoolModel(
+        boolEnum: MyBoolEnum.yes,
+        maybeBoolEnum: null,
+        indexedBoolEnum: MyBoolEnum.yes,
+      );
+      childObj0 = ChildBoolModel(
+        boolEnum: MyBoolEnum.yes,
+        maybeBoolEnum: null,
+        indexedBoolEnum: MyBoolEnum.yes,
+        doubleNegatedBool: true,
+      );
+      childObj1 = ChildBoolModel(
+        boolEnum: MyBoolEnum.yes,
+        maybeBoolEnum: MyBoolEnum.yes,
+        indexedBoolEnum: MyBoolEnum.yes,
+        doubleNegatedBool: false,
+      );
+      childObj2 = ChildBoolModel(
+        boolEnum: MyBoolEnum.no,
+        maybeBoolEnum: null,
+        indexedBoolEnum: MyBoolEnum.no,
+        doubleNegatedBool: false,
+      );
+
+      await isar.tWriteTxn(
+        () => Future.wait([
+          isar.boolModels.tPutAll([obj0, obj1, obj2]),
+          isar.childBoolModels.tPutAll([childObj0, childObj1, childObj2]),
+        ]),
+      );
+    });
+
+    isarTest('Query by filters', () async {
+      await qEqual(
+        isar.boolModels.filter().boolEnumEqualTo(MyBoolEnum.yes).tFindAll(),
+        [obj1, obj2],
+      );
+
+      await qEqual(
+        isar.boolModels
+            .filter()
+            .boolEnumEqualTo(MyBoolEnum.no)
+            .and()
+            .boolEnumEqualTo(MyBoolEnum.yes)
+            .tFindAll(),
+        [],
+      );
+
+      await qEqual(
+        isar.boolModels
+            .filter()
+            .maybeBoolEnumEqualTo(MyBoolEnum.yes)
+            .tFindAll(),
+        [obj1],
+      );
+
+      await qEqual(
+        isar.boolModels.filter().maybeBoolEnumIsNull().tFindAll(),
+        [obj0, obj2],
+      );
+
+      await qEqual(
+        isar.boolModels.filter().not().maybeBoolEnumIsNull().tFindAll(),
+        [obj1],
+      );
+
+      await qEqual(
+        isar.boolModels
+            .filter()
+            .boolEnumEqualTo(MyBoolEnum.no)
+            .or()
+            .maybeBoolEnumIsNull()
+            .tFindAll(),
+        [obj0, obj2],
+      );
+    });
+
+    isarTest('Sort', () async {
+      await qEqual(
+        isar.boolModels.where().sortByBoolEnumDesc().tFindAll(),
+        [obj1, obj2, obj0],
+      );
+
+      await qEqual(
+        isar.boolModels.where().sortByMaybeBoolEnum().tFindAll(),
+        [obj0, obj2, obj1],
+      );
+
+      await qEqual(
+        isar.boolModels
+            .where()
+            .sortByIndexedBoolEnum()
+            .thenByBoolEnumDesc()
+            .tFindAll(),
+        [obj1, obj0, obj2],
+      );
+    });
+
+    isarTest('Query by index', () async {
+      await qEqual(
+        isar.boolModels
+            .where()
+            .indexedBoolEnumEqualTo(MyBoolEnum.no)
+            .tFindAll(),
+        [obj0, obj1],
+      );
+
+      await qEqual(
+        isar.boolModels.where().anyIndexedBoolEnum().tFindAll(),
+        [obj0, obj1, obj2],
+      );
+
+      await qEqual(
+        isar.boolModels
+            .where(sort: Sort.asc)
+            .indexedBoolEnumEqualTo(MyBoolEnum.yes)
+            .or()
+            .indexedBoolEnumNotEqualTo(MyBoolEnum.yes)
+            .indexedBoolEnumProperty()
+            .tFindAll(),
+        [MyBoolEnum.yes, MyBoolEnum.no, MyBoolEnum.no],
+      );
+    });
+
+    isarTest('Query child by filters', () async {
+      await qEqual(
+        isar.childBoolModels.filter().boolEnumEqualTo(MyBoolEnum.no).tFindAll(),
+        [childObj2],
+      );
+
+      await qEqual(
+        isar.childBoolModels
+            .filter()
+            .boolEnumEqualTo(MyBoolEnum.yes)
+            .tFindAll(),
+        [childObj0, childObj1],
+      );
+
+      await qEqual(
+        isar.childBoolModels.filter().maybeBoolEnumIsNull().tFindAll(),
+        [childObj0, childObj2],
+      );
+    });
+
+    isarTest('Query child by index', () async {
+      await qEqual(
+        isar.childBoolModels
+            .where()
+            .indexedBoolEnumEqualTo(MyBoolEnum.yes)
+            .tFindAll(),
+        [childObj0, childObj1],
+      );
+
+      await qEqual(
+        isar.childBoolModels
+            .where()
+            .indexedBoolEnumEqualTo(MyBoolEnum.no)
+            .or()
+            .indexedBoolEnumNotEqualTo(MyBoolEnum.yes)
+            .tFindAll(),
+        [childObj2],
+      );
+    });
+
+    isarTest('Query by double negated bool', () async {
+      await qEqual(
+        isar.childBoolModels.filter().doubleNegatedBoolEqualTo(true).tFindAll(),
+        [childObj0],
+      );
+
+      await qEqual(
+        isar.childBoolModels
+            .filter()
+            .doubleNegatedBoolEqualTo(false)
+            .tFindAll(),
+        [childObj1, childObj2],
+      );
+
+      await qEqual(
+        isar.childBoolModels
+            .filter()
+            .not()
+            .doubleNegatedBoolEqualTo(false)
+            .tFindAll(),
+        [childObj0],
+      );
+    });
+  });
+}

--- a/packages/isar_test/test/converter/bool_converter_test.dart
+++ b/packages/isar_test/test/converter/bool_converter_test.dart
@@ -326,5 +326,34 @@ void main() {
         [childObj0],
       );
     });
+
+    isarTest('Sort by boolEnum', () async {
+      await qEqual(
+        isar.boolModels.where().sortByBoolEnum().tFindAll(),
+        [obj0, obj1, obj2],
+      );
+
+      await qEqual(
+        isar.boolModels.where().sortByBoolEnumDesc().tFindAll(),
+        [obj1, obj2, obj0],
+      );
+
+      await qEqual(
+        isar.childBoolModels.where().sortByBoolEnumDesc().tFindAll(),
+        [childObj0, childObj1, childObj2],
+      );
+    });
+
+    isarTest('Sort by mayBoolEnum', () async {
+      await qEqual(
+        isar.boolModels.where().sortByMaybeBoolEnum().tFindAll(),
+        [obj0, obj2, obj1],
+      );
+
+      await qEqual(
+        isar.boolModels.where().sortByMaybeBoolEnumDesc().tFindAll(),
+        [obj1, obj0, obj2],
+      );
+    });
   });
 }

--- a/packages/isar_test/test/converter/date_time_converter_test.dart
+++ b/packages/isar_test/test/converter/date_time_converter_test.dart
@@ -1,0 +1,201 @@
+import 'package:isar/isar.dart';
+import 'package:test/test.dart';
+
+import '../util/common.dart';
+import '../util/sync_async_helper.dart';
+
+part 'date_time_converter_test.g.dart';
+
+@Collection()
+class DateTimeModel {
+  DateTimeModel({
+    required this.dateTime,
+    required this.nullableDateTime,
+  });
+
+  int id = Isar.autoIncrement;
+
+  @UnixToDateTimeTypeConverter()
+  final DateTime dateTime;
+
+  @UnixToNullableDateTimeTypeConverter()
+  final DateTime? nullableDateTime;
+
+  @override
+  String toString() {
+    return 'DateTimeModel{id: $id, dateTime: $dateTime, nullableDateTime: $nullableDateTime}';
+  }
+
+  @override
+  // ignore: hash_and_equals
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DateTimeModel &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          dateTime == other.dateTime &&
+          nullableDateTime == other.nullableDateTime;
+}
+
+class UnixToDateTimeTypeConverter extends TypeConverter<int, DateTime> {
+  const UnixToDateTimeTypeConverter();
+
+  @override
+  int fromIsar(DateTime date) => date.millisecondsSinceEpoch ~/ 1000;
+
+  @override
+  DateTime toIsar(int unixTimestamp) {
+    return DateTime.fromMillisecondsSinceEpoch(unixTimestamp * 1000);
+  }
+}
+
+class UnixToNullableDateTimeTypeConverter
+    extends TypeConverter<int?, DateTime?> {
+  const UnixToNullableDateTimeTypeConverter();
+
+  @override
+  int? fromIsar(DateTime? date) {
+    if (date == null) return null;
+    return date.millisecondsSinceEpoch ~/ 1000;
+  }
+
+  @override
+  DateTime? toIsar(int? unixTimestamp) {
+    if (unixTimestamp == null) return null;
+    return DateTime.fromMillisecondsSinceEpoch(unixTimestamp * 1000);
+  }
+}
+
+void main() {
+  group('DateTime converter', () {
+    late Isar isar;
+
+    late DateTimeModel obj0;
+    late DateTimeModel obj1;
+    late DateTimeModel obj2;
+    late DateTimeModel obj3;
+    late DateTimeModel obj4;
+    late DateTimeModel obj5;
+
+    setUp(() async {
+      isar = await openTempIsar([DateTimeModelSchema]);
+
+      obj0 = DateTimeModel(
+        dateTime: DateTime(1980, 1, 12),
+        nullableDateTime: DateTime(1992, 7, 21),
+      );
+      obj1 = DateTimeModel(
+        dateTime: DateTime(1500, 3, 27),
+        nullableDateTime: null,
+      );
+      obj2 = DateTimeModel(
+        dateTime: DateTime(2100, 6, 2),
+        nullableDateTime: null,
+      );
+      obj3 = DateTimeModel(
+        dateTime: DateTime(2010, 12, 13),
+        nullableDateTime: DateTime(1942, 3, 3),
+      );
+      obj4 = DateTimeModel(
+        dateTime: DateTime(-42, 5, 22),
+        nullableDateTime: null,
+      );
+      obj5 = DateTimeModel(
+        dateTime: DateTime(2003, 6, 24),
+        nullableDateTime: DateTime(2200, 3, 10),
+      );
+
+      await isar.tWriteTxn(
+        () => isar.dateTimeModels.tPutAll([obj0, obj1, obj2, obj3, obj4, obj5]),
+      );
+    });
+
+    isarTest('Query by dateTime', () async {
+      await qEqual(
+        isar.dateTimeModels
+            .filter()
+            .dateTimeEqualTo(DateTime(2010, 12, 13))
+            .tFindAll(),
+        [obj3],
+      );
+
+      await qEqual(
+        isar.dateTimeModels
+            .filter()
+            .dateTimeGreaterThan(DateTime(2000))
+            .tFindAll(),
+        [obj2, obj3, obj5],
+      );
+
+      await qEqual(
+        isar.dateTimeModels
+            .filter()
+            .dateTimeBetween(DateTime(1980, 1, 2), DateTime(2005, 1, 2))
+            .tFindAll(),
+        [obj0, obj5],
+      );
+
+      await qEqual(
+        isar.dateTimeModels.filter().dateTimeLessThan(DateTime(0)).tFindAll(),
+        [obj4],
+      );
+    });
+
+    isarTest('Query by nullableDateTime', () async {
+      await qEqual(
+        isar.dateTimeModels.filter().nullableDateTimeIsNull().tFindAll(),
+        [obj1, obj2, obj4],
+      );
+
+      await qEqual(
+        isar.dateTimeModels
+            .filter()
+            .nullableDateTimeGreaterThan(DateTime(2000))
+            .tFindAll(),
+        [obj5],
+      );
+
+      // FIXME: lessThan queries on nullable dates also returns objects where
+      //  the field is null
+      await qEqual(
+        isar.dateTimeModels
+            .filter()
+            .nullableDateTimeLessThan(DateTime(1969))
+            .tFindAll(),
+        [obj3],
+      );
+
+      await qEqual(
+        isar.dateTimeModels
+            .filter()
+            .nullableDateTimeBetween(DateTime(1950), DateTime(9999))
+            .tFindAll(),
+        [obj0, obj5],
+      );
+    });
+
+    isarTest('Sort by dateTime', () async {
+      await qEqual(
+        isar.dateTimeModels.where().sortByDateTime().tFindAll(),
+        [obj4, obj1, obj0, obj5, obj3, obj2],
+      );
+
+      await qEqual(
+        isar.dateTimeModels.where().sortByDateTimeDesc().tFindAll(),
+        [obj2, obj3, obj5, obj0, obj1, obj4],
+      );
+    });
+
+    isarTest('Sort by nullableDateTime', () async {
+      await qEqual(
+        isar.dateTimeModels.where().sortByNullableDateTime().tFindAll(),
+        [obj1, obj2, obj4, obj3, obj0, obj5],
+      );
+
+      await qEqual(
+        isar.dateTimeModels.where().sortByNullableDateTimeDesc().tFindAll(),
+        [obj5, obj0, obj3, obj1, obj2, obj4],
+      );
+    });
+  });
+}

--- a/packages/isar_test/test/converter/double_converter_test.dart
+++ b/packages/isar_test/test/converter/double_converter_test.dart
@@ -149,6 +149,22 @@ void main() {
             .tFindAll(),
         [],
       );
+
+      await qEqual(
+        isar.doubleModels
+            .where()
+            .someIntEqualToValueLessThan(0, Values.first)
+            .tFindAll(),
+        [],
+      );
+
+      await qEqual(
+        isar.doubleModels
+            .where()
+            .someIntEqualToValueLessThan(0, Values.second)
+            .tFindAll(),
+        [obj1],
+      );
     });
   });
 }

--- a/packages/isar_test/test/converter/double_converter_test.dart
+++ b/packages/isar_test/test/converter/double_converter_test.dart
@@ -1,0 +1,154 @@
+import 'package:isar/isar.dart';
+import 'package:test/test.dart';
+
+import '../util/common.dart';
+import '../util/sync_async_helper.dart';
+
+part 'double_converter_test.g.dart';
+
+@Collection()
+class DoubleModel {
+  DoubleModel(this.value, this.someInt);
+
+  int id = Isar.autoIncrement;
+
+  @ValuesTypeConverter()
+  final Values value;
+
+  @Index(composite: [CompositeIndex('value')])
+  final int someInt;
+
+  @override
+  String toString() {
+    return 'DoubleModel{id: $id, value: $value, someInt: $someInt}';
+  }
+
+  @override
+  // ignore: hash_and_equals
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DoubleModel &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          value == other.value &&
+          someInt == other.someInt;
+}
+
+enum Values {
+  first(0),
+  second(5123.582134),
+  third(584114559420.110239),
+  fourth(-5812903859.4583),
+  fifth(349.1),
+  sixth(-3659.1);
+
+  const Values(this.value);
+
+  final double value;
+}
+
+class ValuesTypeConverter extends TypeConverter<Values, double> {
+  const ValuesTypeConverter();
+
+  @override
+  Values fromIsar(double value) {
+    return Values.values.firstWhere((element) => element.value == value);
+  }
+
+  @override
+  double toIsar(Values value) => value.value;
+}
+
+void main() {
+  group('Double converter', () {
+    late Isar isar;
+
+    late DoubleModel obj0;
+    late DoubleModel obj1;
+    late DoubleModel obj2;
+    late DoubleModel obj3;
+    late DoubleModel obj4;
+
+    setUp(() async {
+      isar = await openTempIsar([DoubleModelSchema]);
+
+      obj0 = DoubleModel(Values.fifth, 42);
+      obj1 = DoubleModel(Values.first, 0);
+      obj2 = DoubleModel(Values.sixth, -20);
+      obj3 = DoubleModel(Values.first, 12);
+      obj4 = DoubleModel(Values.third, 3);
+
+      await isar.tWriteTxn(
+        () => isar.doubleModels.tPutAll([obj0, obj1, obj2, obj3, obj4]),
+      );
+    });
+
+    tearDown(() => isar.close());
+
+    isarTest('Query by value', () async {
+      await qEqual(
+        isar.doubleModels.filter().valueGreaterThan(Values.first).tFindAll(),
+        [obj0, obj4],
+      );
+
+      await qEqual(
+        isar.doubleModels
+            .filter()
+            .valueBetween(Values.fourth, Values.second)
+            .tFindAll(),
+        [obj0, obj1, obj2, obj3],
+      );
+
+      await qEqual(
+        isar.doubleModels.filter().valueLessThan(Values.fifth).tFindAll(),
+        [obj1, obj2, obj3],
+      );
+
+      await qEqual(
+        isar.doubleModels
+            .filter()
+            .valueBetween(Values.fourth, Values.fifth)
+            .tFindAll(),
+        [obj1, obj2, obj3],
+      );
+
+      await qEqual(
+        isar.doubleModels.filter().valueGreaterThan(Values.third).tFindAll(),
+        [],
+      );
+    });
+
+    isarTest('Query by someIntValue', () async {
+      await qEqual(
+        isar.doubleModels.where().someIntEqualToAnyValue(42).tFindAll(),
+        [obj0],
+      );
+
+      await qEqual(
+        isar.doubleModels
+            .where()
+            .someIntEqualToValueGreaterThan(-20, Values.fourth)
+            .tFindAll(),
+        [obj2],
+      );
+
+      // FIXME: TypeConverter is not called on `Values.first` and `Values.fifth`
+      //  in the generated code.
+      //
+      // Current:
+      // lower: [someInt, lowerValue],
+      // upper: [someInt, upperValue],
+      //
+      // Should be:
+      // lower: [someInt, _doubleModelValuesTypeConverter.toIsar(lowerValue)],
+      // upper: [someInt, _doubleModelValuesTypeConverter.toIsar(upperValue)],
+      await qEqual(
+        isar.doubleModels
+            .where()
+            .someIntEqualToValueBetween(12, Values.first, Values.fifth)
+            .tFindAll(),
+        [],
+      );
+    });
+  });
+}

--- a/packages/isar_test/test/converter/int_converter_test.dart
+++ b/packages/isar_test/test/converter/int_converter_test.dart
@@ -1,0 +1,245 @@
+import 'package:isar/isar.dart';
+import 'package:test/test.dart';
+
+import '../util/common.dart';
+import '../util/sync_async_helper.dart';
+
+part 'int_converter_test.g.dart';
+
+@Collection()
+class IntModel {
+  IntModel({
+    required this.offsettedInt,
+    required this.day,
+    required this.otherDay,
+  });
+
+  int id = Isar.autoIncrement;
+
+  @OffsettedIntTypeConverter()
+  final int offsettedInt;
+
+  @Index(composite: [CompositeIndex('otherDay')])
+  @DaysTypeConverter()
+  final Days day;
+
+  @DaysTypeConverter()
+  final Days otherDay;
+
+  @override
+  String toString() {
+    return 'IntModel{id: $id, offsettedInt: $offsettedInt, day: $day}';
+  }
+
+  @override
+  // ignore: hash_and_equals
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is IntModel &&
+            runtimeType == other.runtimeType &&
+            id == other.id &&
+            offsettedInt == other.offsettedInt &&
+            day == other.day;
+  }
+}
+
+class OffsettedIntTypeConverter extends TypeConverter<int, int> {
+  const OffsettedIntTypeConverter();
+
+  @override
+  int fromIsar(int value) => value - 42;
+
+  @override
+  int toIsar(int value) => value + 42;
+}
+
+enum Days {
+  sunday(0),
+  monday(1),
+  tuesday(2),
+  wednesday(3),
+  thursday(4),
+  friday(5),
+  saturday(6);
+
+  const Days(this.value);
+
+  final int value;
+}
+
+class DaysTypeConverter extends TypeConverter<Days, int> {
+  const DaysTypeConverter();
+
+  @override
+  Days fromIsar(int value) {
+    return Days.values.firstWhere((element) => element.value == value);
+  }
+
+  @override
+  int toIsar(Days day) => day.value;
+}
+
+void main() {
+  group('Int converter', () {
+    late Isar isar;
+
+    late IntModel obj0;
+    late IntModel obj1;
+    late IntModel obj2;
+    late IntModel obj3;
+    late IntModel obj4;
+    late IntModel obj5;
+    late IntModel obj6;
+    late IntModel obj7;
+
+    setUp(() async {
+      isar = await openTempIsar([IntModelSchema]);
+
+      obj0 = IntModel(
+        offsettedInt: 0,
+        day: Days.wednesday,
+        otherDay: Days.sunday,
+      );
+      obj1 = IntModel(
+        offsettedInt: 24,
+        day: Days.saturday,
+        otherDay: Days.monday,
+      );
+      obj2 = IntModel(
+        offsettedInt: 42,
+        day: Days.thursday,
+        otherDay: Days.tuesday,
+      );
+      obj3 = IntModel(
+        offsettedInt: -1024,
+        day: Days.saturday,
+        otherDay: Days.wednesday,
+      );
+      obj4 = IntModel(
+        offsettedInt: 2048,
+        day: Days.monday,
+        otherDay: Days.thursday,
+      );
+      obj5 = IntModel(
+        offsettedInt: -0,
+        day: Days.sunday,
+        otherDay: Days.friday,
+      );
+      obj6 = IntModel(
+        offsettedInt: 5673873209,
+        day: Days.saturday,
+        otherDay: Days.saturday,
+      );
+      obj7 = IntModel(
+        offsettedInt: 40,
+        day: Days.friday,
+        otherDay: Days.saturday,
+      );
+
+      await isar.tWriteTxn(
+        () => isar.intModels.tPutAll([
+          obj0,
+          obj1,
+          obj2,
+          obj3,
+          obj4,
+          obj5,
+          obj6,
+          obj7,
+        ]),
+      );
+    });
+
+    tearDown(() => isar.close());
+
+    isarTest('Query by offsettedInt', () async {
+      await qEqual(
+        isar.intModels
+            .filter()
+            .offsettedIntBetween(
+              0,
+              42,
+              includeLower: false,
+              includeUpper: false,
+            )
+            .tFindAll(),
+        [obj1, obj7],
+      );
+
+      await qEqual(
+        isar.intModels.filter().offsettedIntLessThan(1).tFindAll(),
+        [obj0, obj3, obj5],
+      );
+
+      await qEqual(
+        isar.intModels.filter().offsettedIntEqualTo(42).tFindAll(),
+        [obj2],
+      );
+
+      await qEqual(
+        isar.intModels.filter().offsettedIntGreaterThan(7).tFindAll(),
+        [obj1, obj2, obj4, obj6, obj7],
+      );
+    });
+
+    isarTest('Query by day', () async {
+      await qEqual(
+        isar.intModels.filter().dayEqualTo(Days.saturday).tFindAll(),
+        [obj1, obj3, obj6],
+      );
+
+      await qEqual(
+        isar.intModels.filter().dayBetween(Days.monday, Days.friday).tFindAll(),
+        [obj0, obj2, obj4, obj7],
+      );
+
+      await qEqual(
+        isar.intModels.filter().dayLessThan(Days.tuesday).tFindAll(),
+        [obj4, obj5],
+      );
+
+      await qEqual(
+        isar.intModels.filter().dayGreaterThan(Days.wednesday).tFindAll(),
+        [obj1, obj2, obj3, obj6, obj7],
+      );
+
+      await qEqual(
+        isar.intModels
+            .filter()
+            .dayGreaterThan(Days.monday)
+            .and()
+            .dayLessThan(Days.friday)
+            .and()
+            .dayGreaterThan(Days.wednesday)
+            .tFindAll(),
+        [obj2],
+      );
+    });
+
+    isarTest('Query by dayOtherDay index', () async {
+      await qEqual(
+        isar.intModels
+            .where()
+            .dayOtherDayEqualTo(Days.saturday, Days.saturday)
+            .tFindAll(),
+        [obj6],
+      );
+
+      await qEqual(
+        isar.intModels
+            .where()
+            .dayGreaterThanAnyOtherDay(Days.wednesday)
+            .tFindAll(),
+        [obj2, obj7, obj1, obj3, obj6],
+      );
+
+      await qEqual(
+        isar.intModels
+            .where()
+            .dayEqualToOtherDayNotEqualTo(Days.saturday, Days.wednesday)
+            .tFindAll(),
+        [obj1, obj6],
+      );
+    });
+  });
+}

--- a/packages/isar_test/test/converter/multiple_converter_test.dart
+++ b/packages/isar_test/test/converter/multiple_converter_test.dart
@@ -1,12 +1,23 @@
 import 'package:isar/isar.dart';
 import 'package:test/test.dart';
 
-import 'util/common.dart';
+import '../util/common.dart';
 
-part 'converter_test.g.dart';
+part 'multiple_converter_test.g.dart';
 
 @Collection()
-class ConverterModel {
+class MultiConverterModel {
+  MultiConverterModel({
+    required this.id,
+    required this.boolValue,
+    required this.intValue,
+    required this.longValue,
+    required this.floatValue,
+    required this.doubleValue,
+    required this.dateValue,
+    required this.stringValue,
+  });
+
   @Id()
   int? id;
 
@@ -43,7 +54,7 @@ class ConverterModel {
   @override
   // ignore: hash_and_equals
   bool operator ==(Object other) {
-    if (other is ConverterModel) {
+    if (other is MultiConverterModel) {
       return boolValue == other.boolValue &&
           intValue == other.intValue &&
           longValue == other.longValue &&
@@ -128,15 +139,16 @@ class StringConverter extends TypeConverter<String, int> {
 }
 
 void main() {
-  final converterObject = ConverterModel()
-    ..id = 123
-    ..boolValue = true
-    ..intValue = 25
-    ..floatValue = 17.17
-    ..longValue = 123123
-    ..doubleValue = 123.123
-    ..dateValue = DateTime.fromMillisecondsSinceEpoch(123123)
-    ..stringValue = 'five';
+  final converterObject = MultiConverterModel(
+    id: 123,
+    boolValue: true,
+    intValue: 25,
+    floatValue: 17.17,
+    longValue: 123123,
+    doubleValue: 123.123,
+    dateValue: DateTime.fromMillisecondsSinceEpoch(123123),
+    stringValue: 'five',
+  );
 
   final converterObjectJson = <String, Object>{
     'id': 123,
@@ -149,29 +161,29 @@ void main() {
     'stringValue': 5,
   };
 
-  group('Converter', () {
-    /*isarTest('toIsar()', () async {
-      final isar = await openTempIsar([ConverterModelSchema]);
+  group('Multiple converter', () {
+    isarTest('toIsar()', () async {
+      final isar = await openTempIsar([MultiConverterModelSchema]);
 
       await isar.writeTxn(() async {
-        await isar.converterModels.put(_converterObject);
+        await isar.multiConverterModels.put(converterObject);
       });
 
-      final json = await isar.converterModels.where().exportJson();
-      expect(json[0], _converterObjectJson);
+      final json = await isar.multiConverterModels.where().exportJson();
+      expect(json[0], converterObjectJson);
 
       await isar.close();
-    });*/
+    });
 
     isarTest('fromIsar()', () async {
-      final isar = await openTempIsar([ConverterModelSchema]);
+      final isar = await openTempIsar([MultiConverterModelSchema]);
 
       await isar.writeTxn(() async {
-        await isar.converterModels.importJson([converterObjectJson]);
+        await isar.multiConverterModels.importJson([converterObjectJson]);
       });
 
       expect(
-        await isar.converterModels.get(123),
+        await isar.multiConverterModels.get(123),
         converterObject,
       );
 

--- a/packages/isar_test/test/converter/string_converter_test.dart
+++ b/packages/isar_test/test/converter/string_converter_test.dart
@@ -1,0 +1,185 @@
+import 'package:isar/isar.dart';
+import 'package:test/test.dart';
+
+import '../util/common.dart';
+import '../util/sync_async_helper.dart';
+
+part 'string_converter_test.g.dart';
+
+@Collection()
+class StringModel {
+  StringModel({
+    required this.authProvider,
+    required this.number,
+    required this.nullableNumber,
+  });
+
+  final id = Isar.autoIncrement;
+
+  @AuthProvidersTypeConverter()
+  final AuthProviders authProvider;
+
+  @NumStringifierTypeConverter()
+  @Index()
+  final num number;
+
+  @NullableNumStringifierTypeConverter()
+  final num? nullableNumber;
+
+  @override
+  String toString() {
+    return 'StringModel{id: $id, authProvider: $authProvider, number: $number, nullableNumber: $nullableNumber}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is StringModel &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          authProvider == other.authProvider &&
+          number == other.number &&
+          nullableNumber == other.nullableNumber;
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      authProvider.hashCode ^
+      number.hashCode ^
+      nullableNumber.hashCode;
+}
+
+enum AuthProviders {
+  password('password'),
+  google('google.com'),
+  facebook('facebook.com'),
+  apple('apple.com'),
+  github('github.com'),
+  none(null);
+
+  const AuthProviders(this.value);
+
+  final String? value;
+}
+
+class AuthProvidersTypeConverter extends TypeConverter<AuthProviders, String?> {
+  const AuthProvidersTypeConverter();
+
+  @override
+  AuthProviders fromIsar(String? value) {
+    return AuthProviders.values.firstWhere(
+      (provider) => provider.value == value,
+    );
+  }
+
+  @override
+  String? toIsar(AuthProviders provider) => provider.value;
+}
+
+class NumStringifierTypeConverter extends TypeConverter<num, String> {
+  const NumStringifierTypeConverter();
+
+  @override
+  num fromIsar(String value) => num.parse(value);
+
+  @override
+  String toIsar(num value) => value.toString();
+}
+
+class NullableNumStringifierTypeConverter extends TypeConverter<num?, String?> {
+  const NullableNumStringifierTypeConverter();
+
+  @override
+  num? fromIsar(String? value) {
+    if (value == null) return null;
+    return num.parse(value);
+  }
+
+  @override
+  String? toIsar(num? value) => value?.toString();
+}
+
+void main() {
+  group('String converter', () {
+    late Isar isar;
+
+    late StringModel obj0;
+    late StringModel obj1;
+    late StringModel obj2;
+    late StringModel obj3;
+    late StringModel obj4;
+    late StringModel obj5;
+
+    setUp(() async {
+      isar = await openTempIsar([StringModelSchema]);
+
+      obj0 = StringModel(
+        authProvider: AuthProviders.github,
+        number: 1,
+        nullableNumber: null,
+      );
+      obj1 = StringModel(
+        authProvider: AuthProviders.facebook,
+        number: 42.12,
+        nullableNumber: 123,
+      );
+      obj2 = StringModel(
+        authProvider: AuthProviders.none,
+        number: 0,
+        nullableNumber: null,
+      );
+      obj3 = StringModel(
+        authProvider: AuthProviders.password,
+        number: 1024,
+        nullableNumber: null,
+      );
+      obj4 = StringModel(
+        authProvider: AuthProviders.apple,
+        number: 0.5,
+        nullableNumber: 92,
+      );
+      obj5 = StringModel(
+        authProvider: AuthProviders.github,
+        number: -2048,
+        nullableNumber: 42.42,
+      );
+
+      await isar.tWriteTxn(
+        () => isar.stringModels.tPutAll([obj0, obj1, obj2, obj3, obj4, obj5]),
+      );
+    });
+
+    tearDown(() => isar.close());
+
+    // FIXME: This seems to be an issue with the generator, that generates
+    // methods which don't support nullable string as argument
+    //
+    // test/converter/string_converter_test.g.dart:608:64:
+    // Error: The argument type 'String?' can't be assigned to the parameter
+    // type 'String' because 'String?' is nullable and 'String' isn't.
+    //
+    isarTest('Query by authProvider', () async {
+      await qEqual(
+        isar.stringModels
+            .filter()
+            .authProviderEqualTo(AuthProviders.github)
+            .tFindAll(),
+        [obj0, obj5],
+      );
+    });
+
+    isarTest('Query by number index', () async {
+      await qEqual(
+        isar.stringModels
+            .where()
+            .numberEqualTo(1)
+            .or()
+            .numberEqualTo(-2048)
+            .tFindAll(),
+        [obj0, obj5],
+      );
+    });
+
+    // TODO(jtplouffe): implement more tests once the generator issues are fixed
+  });
+}


### PR DESCRIPTION
I implemented a lot more converter tests.
I created a `converter` directory for everything related to converter tests, and I made a separate test file for bools, ints, doubles, strings and DateTimes.

I found some bugs while writing the tests (I don't know if there are directly related to converters)
- On the `DateTime` -> `int` converter, a `lessThan` query with on a `DateTime?` field will also return the object where the value is null (maybe this is not a bug?)

- In the `Double` converter tests, a query on the composite index of int + `Values` (which is an enum converted to double), a `intEqualToValueBetween(...)` causes an exception of `type 'Values' is not a subtype of type 'double?' ...`.

- For the `String` converter test, the generated file won't compile, due to nullable String types. This seems to be the same bug as #468. 