### PR TITLE
fix loading links on unsaved object

### DIFF
--- a/packages/isar/lib/src/common/isar_link_common.dart
+++ b/packages/isar/lib/src/common/isar_link_common.dart
@@ -203,7 +203,7 @@ abstract class IsarLinksCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
   bool get isLoaded => _isLoaded;
 
   HashSet<OBJ> get _loadedObjects {
-    if (!_isLoaded && !_kIsWeb) {
+    if (!_isLoaded && !_kIsWeb && _objectId != null) {
       loadSync();
     }
     return _objects;

--- a/packages/isar_test/test/link_test.dart
+++ b/packages/isar_test/test/link_test.dart
@@ -327,6 +327,21 @@ void main() {
         expect(newA1.selfLinks, {objA2, objA3});
       });
 
+      isarTest('save link in unsaved object', () async {
+        await isar.tWriteTxn(() => linksA.tPutAll([objA2, objA3]));
+
+        objA1.selfLinks.addAll([objA2, objA3]);
+
+        await isar.tWriteTxn(() async {
+          await linksA.tPut(objA1);
+          await objA1.selfLinks.tSave();
+        });
+
+        final newA1 = await linksA.tGet(objA1.id!);
+        await newA1!.selfLinks.tLoad();
+        expect(newA1.selfLinks, {objA2, objA3});
+      });
+
       isarTest('delete source', () async {
         await isar.tWriteTxn(() => linksA.tPutAll([objA1, objA2, objA3]));
 


### PR DESCRIPTION
after auto links loading added, calling .add/.addAll for IsarLinks on unsaved objects throws **Containing object needs to be managed by Isar to use this method.**