### PR TITLE
Fix for schema test following recent changes to links in schema

### DIFF
--- a/packages/isar_test/test/schema_test.dart
+++ b/packages/isar_test/test/schema_test.dart
@@ -255,8 +255,8 @@ void main() {
         }
       ],
       'links': [
-        {'name': r'$dollar$Link', 'target': r'$Dollar$Model'},
-        {'name': r'$dollar$Links', 'target': r'$Dollar$Model'}
+        {'name': r'$dollar$Link', 'target': r'$Dollar$Model', 'single': true},
+        {'name': r'$dollar$Links', 'target': r'$Dollar$Model', 'single': false}
       ]
     });
   });
@@ -708,10 +708,10 @@ void main() {
           }
         ],
         'links': [
-          {'name': 'link', 'target': 'SchemaTestModel'},
-          {'name': 'links', 'target': 'SchemaTestModel'},
-          {'name': 'renamedLink', 'target': 'SchemaTestModel'},
-          {'name': 'renamedLinks', 'target': 'SchemaTestModel'}
+          {'name': 'link', 'target': 'SchemaTestModel', 'single': true},
+          {'name': 'links', 'target': 'SchemaTestModel', 'single': false},
+          {'name': 'renamedLink', 'target': 'SchemaTestModel', 'single': true},
+          {'name': 'renamedLinks', 'target': 'SchemaTestModel', 'single': false}
         ]
       },
     );


### PR DESCRIPTION
The property `single` was added to the schema (in order for the inspector to distinguish between link / links I think?), so I updated the test, and added `single: true` to `IsarLink` and `single: false` to `IsarLinks`.