### PR TITLE
String isEmpty filter test

### DIFF
--- a/packages/isar_test/test/util/common.dart
+++ b/packages/isar_test/test/util/common.dart
@@ -102,6 +102,7 @@ void isarTest(
         );
       },
       timeout: timeout ?? const Timeout(Duration(minutes: 10)),
+      skip: skip,
     );
   }
 
@@ -117,6 +118,11 @@ void isarTest(
 @isTest
 void isarTestVm(String name, dynamic Function() body) {
   isarTest(name, body, skip: kIsWeb);
+}
+
+@isTest
+void isarTestWeb(String name, dynamic Function() body) {
+  isarTest(name, body, skip: !kIsWeb);
 }
 
 @isTest


### PR DESCRIPTION
I added the `stringIsEmpty()` filter test and I also refactored the filter string test.
I will make another PR for the string list tests.

Also, is it normal that we can't use the `isEmpty` on string index like `.where().stringIsEmpty()`? It seems to only be available in `filter` queries.