### PR TITLE
Add issue_tracker link

### DIFF
--- a/packages/isar/pubspec.yaml
+++ b/packages/isar/pubspec.yaml
@@ -2,6 +2,7 @@ name: isar
 description: Extremely fast, easy to use, and fully async NoSQL database for Flutter.
 version: 3.0.0-dev.13
 repository: https://github.com/isar/isar
+issue_tracker: https://github.com/isar/isar/issues
 homepage: https://isar.dev
 
 environment:


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).