### PR TITLE
Added access to new objects in links after save

### DIFF
--- a/packages/isar/lib/src/common/isar_links_common.dart
+++ b/packages/isar/lib/src/common/isar_links_common.dart
@@ -96,6 +96,13 @@ abstract class IsarLinksCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
 
     await update(link: addedObjects, unlink: removedObjects);
 
+    for (final object in addedObjects) {
+      final id = getId(object);
+      if (id != Isar.autoIncrement) {
+        _objects[id] = object;
+      }
+    }
+
     addedObjects.clear();
     removedObjects.clear();
     isLoaded = true;
@@ -108,6 +115,13 @@ abstract class IsarLinksCommon<OBJ> extends IsarLinkBaseImpl<OBJ>
     }
 
     updateSync(link: addedObjects, unlink: removedObjects);
+
+    for (final object in addedObjects) {
+      final id = getId(object);
+      if (id != Isar.autoIncrement) {
+        _objects[id] = object;
+      }
+    }
 
     addedObjects.clear();
     removedObjects.clear();

--- a/packages/isar_test/test/links/backlink_test.dart
+++ b/packages/isar_test/test/links/backlink_test.dart
@@ -55,7 +55,7 @@ class LinkModelB {
 }
 
 void main() {
-  group('Link', () {
+  group('Backlink', () {
     late Isar isar;
     late LinkModelA a1;
     late LinkModelA a2;

--- a/packages/isar_test/test/links/links_test.dart
+++ b/packages/isar_test/test/links/links_test.dart
@@ -47,7 +47,7 @@ class LinkModelB {
 }
 
 void main() {
-  group('Link', () {
+  group('Links', () {
     late Isar isar;
     late LinkModelA a1;
     late LinkModelA a2;


### PR DESCRIPTION
When adding new objects to links, and saving them with `saveLinks: true`, if the linked objects don't have a `final` id, we will now be able to access them.
This is fixed by iterating over the added objects after the update, and if the id is not `Isar.autoIncrement`, we add it to the `_objects` map.

Before, we had to reload the links or re-query the parent object if we wanted to access the new objects in a link after saving it.

Also, I don't know if it's on purpose, but on master links are no longer loading automatically.