### PR TITLE
wip #678: support for arm64 ios sim

### DIFF
--- a/packages/isar_flutter_libs/ios/isar_flutter_libs.podspec
+++ b/packages/isar_flutter_libs/ios/isar_flutter_libs.podspec
@@ -17,12 +17,12 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 
     'DEFINES_MODULE' => 'YES',
     'ENABLE_BITCODE' => 'NO',
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386 arm64',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
     'EXCLUDED_ARCHS[sdk=iphoneos*]' => 'armv7',
     'OTHER_LDFLAGS' => '-force_load $(PODS_TARGET_SRCROOT)/libisar.a'
   }
   s.user_target_xcconfig = { 
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386 arm64',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
     'EXCLUDED_ARCHS[sdk=iphoneos*]' => 'armv7'
   }
   s.swift_version = '5.0'

--- a/tool/build_ios.sh
+++ b/tool/build_ios.sh
@@ -1,5 +1,10 @@
-rustup target add aarch64-apple-ios x86_64-apple-ios
+rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
+
+export IPHONEOS_DEPLOYMENT_TARGET=10.0
+
 cargo build --target aarch64-apple-ios --release
 cargo build --target x86_64-apple-ios --release
+cargo build --target aarch64-apple-ios-sim --release
 
 lipo "target/aarch64-apple-ios/release/libisar.a" "target/x86_64-apple-ios/release/libisar.a" -output "libisar_ios.a" -create
+lipo "target/x86_64-apple-ios/release/libisar.a" "target/aarch64-apple-ios-sim/release/libisar.a" -output "libisar_ios_sim.a" -create


### PR DESCRIPTION
## WIP for #678 
- Removed `arm64` from pod spec excluded arch
- Added `aarch64-apple-ios-sim` target to cargo build and limo
- Export `IPHONEOS_DEPLOYMENT_TARGET=10.0` environment variable, since `-mios-simulator-version-min=10.0` doesn't seem to work in `packages/mdbx_sys/build.rs`
_Reference: https://github.com/rust-lang/cc-rs/pull/433/files#_

I did not realized that `aarch64-apple-ios` and `aarch64-apple-ios-sim` has to be shipped separately because it's the same arch. This fix might need XCframework or a workaround to ship `aarch64-apple-ios-sim`.