### PR TITLE
Fix loading-image not being loaded

### DIFF
--- a/packages/isar_inspector/web/index.html
+++ b/packages/isar_inspector/web/index.html
@@ -91,7 +91,7 @@
 
 <body>
 <section id="loader">
-  <img src="../assets/logo.png" alt="Isar Logo">
+  <img src="assets/assets/logo.png" alt="Isar Logo">
   <span id="loader-info-text"></span>
 </section>
   <!-- This script installs service_worker.js to provide PWA functionality to


### PR DESCRIPTION
The loader image (the Isar logo in this case) wasn't loaded in production due to the wrong image path being provided. See [the current inspector version](https://inspect.isar.dev/3.0.3/). It currently looks like this:
![image](https://user-images.githubusercontent.com/38863733/201875533-18615daa-4400-4438-a7f1-06ef26863dd8.png)

This isn't in line with the [documented behavior in the flutter docs](https://docs.flutter.dev/deployment/web#building-the-app-for-release). Therefor this may be unwanted behavior and could be changed in the future. Someone should keep an eye out for that.