### PR TITLE
refactor: ignore lint rule “always_specify_types"

### DIFF
--- a/packages/isar_generator/lib/src/collection_generator.dart
+++ b/packages/isar_generator/lib/src/collection_generator.dart
@@ -33,6 +33,7 @@ const ignoreLints = [
   'prefer_final_locals',
   'avoid_js_rounded_ints',
   'avoid_positional_boolean_parameters',
+  'always_specify_types',
 ];
 
 class IsarCollectionGenerator extends GeneratorForAnnotation<Collection> {


### PR DESCRIPTION
In default flutter `analysis_options.yaml` file (https://github.com/flutter/flutter/blob/master/analysis_options.yaml#L41), the lint rule `always_specify_types` is defined, so shouldn't we ignore that too?