### PR TITLE
Fix integer literal in JavaScript

### DIFF
--- a/packages/isar_generator/lib/src/code_gen/collection_schema_generator.dart
+++ b/packages/isar_generator/lib/src/code_gen/collection_schema_generator.dart
@@ -20,7 +20,7 @@ String generateSchema(ObjectInfo object) {
 
   code += '''
     name: r'${object.isarName}',
-    id: ${object.id},
+    id: ${BigInt.parse(object.id.toString()).toUnsigned(48)},
     properties: {$properties},
 
     estimateSize: ${object.estimateSizeName},


### PR DESCRIPTION
This is not a bug with flutter see: https://api.dart.dev/stable/2.8.4/dart-core/int-class.html

Note: When compiling to JavaScript, integers are restricted to values that can be represented exactly by double-precision floating point values. The available integer values include all integers between -2^53 and 2^53, and some integers with larger magnitude. That includes some integers larger than 2^63. The behavior of the operators and methods in the int class therefore sometimes differs between the Dart VM and Dart code compiled to JavaScript. For example, the bitwise operators truncate their operands to 32-bit integers when compiled to JavaScript.

You might try using a BigInt class: https://api.dart.dev/stable/2.8.4/dart-core/BigInt-class.html

Refactor the code in isar_generator package. 
Path - > isar_generator package -> src -> code_gen->collection_scheme_generator.dart -> line number 23 -> id: **Replace** id: ${object.id} **to** ${BigInt.parse(object.id.toString()).toUnsigned(48)},