### PR TITLE
docs: fix german code example

### DIFF
--- a/docs/docs/de/tutorials/quickstart.md
+++ b/docs/docs/de/tutorials/quickstart.md
@@ -23,6 +23,9 @@ Annotiere deine Collection-Klassen mit `@collection` und wähle ein `Id`-Feld.
 
 ```dart
 part 'email.g.dart'
+
+@collection
+class User {
   Id id = Isar.autoIncrement; // Für auto-increment kannst du auch id = null zuweisen 
 
   String? name;


### PR DESCRIPTION
The code example was missing some parts. The relevant changes were copied from the english version…