### PR TITLE
docs: changed some declarations in the docs from email to user

### DIFF
--- a/docs/docs/de/tutorials/quickstart.md
+++ b/docs/docs/de/tutorials/quickstart.md
@@ -22,7 +22,7 @@ flutter pub add -d isar_generator build_runner
 Annotiere deine Collection-Klassen mit `@collection` und wähle ein `Id`-Feld.
 
 ```dart
-part 'email.g.dart'
+part 'user.g.dart';
 
 @collection
 class User {

--- a/docs/docs/de/tutorials/quickstart.md
+++ b/docs/docs/de/tutorials/quickstart.md
@@ -55,7 +55,7 @@ flutter pub run build_runner build
 Öffne eine neue Isar-Instanz und übergebe alle Collection-Schemata. Optional kannst du einen Instanznamen und ein Verzeichnis angeben.
 
 ```dart
-final isar = await Isar.open([EmailSchema]);
+final isar = await Isar.open([UserSchema]);
 ```
 
 ## 5. Schreiben und lesen

--- a/docs/docs/es/tutorials/quickstart.md
+++ b/docs/docs/es/tutorials/quickstart.md
@@ -22,7 +22,7 @@ flutter pub add -d isar_generator build_runner
 Anota tus clases de colecciones con `@collection` y elige un campo `Id`.
 
 ```dart
-part 'email.g.dart';
+part 'user.g.dart';
 
 @collection
 class User {

--- a/docs/docs/es/tutorials/quickstart.md
+++ b/docs/docs/es/tutorials/quickstart.md
@@ -55,7 +55,7 @@ flutter pub run build_runner build
 Abre una nueva instalcia Isar y pásale todos los esquemas de tu colección. Opcionalmente puedes especificar un nombre para la instancia y un directorio.
 
 ```dart
-final isar = await Isar.open([EmailSchema]);
+final isar = await Isar.open([UserSchema]);
 ```
 
 ## 5. Lee y escribe

--- a/docs/docs/fr/tutorials/quickstart.md
+++ b/docs/docs/fr/tutorials/quickstart.md
@@ -55,7 +55,7 @@ flutter pub run build_runner build
 Ouvrez une nouvelle instance d'Isar et passez tous vos schémas de collection. En option, vous pouvez spécifier un nom d'instance et un dossier.
 
 ```dart
-final isar = await Isar.open([EmailSchema]);
+final isar = await Isar.open([UserSchema]);
 ```
 
 ## 5. Écriture et lecture

--- a/docs/docs/fr/tutorials/quickstart.md
+++ b/docs/docs/fr/tutorials/quickstart.md
@@ -22,7 +22,7 @@ flutter pub add -d isar_generator build_runner
 Annotez vos classes de collection avec `@collection` et choisissez un champ `Id`.
 
 ```dart
-part 'email.g.dart';
+part 'user.g.dart';
 
 @collection
 class User {

--- a/docs/docs/it/tutorials/quickstart.md
+++ b/docs/docs/it/tutorials/quickstart.md
@@ -22,7 +22,7 @@ flutter pub add -d isar_generator build_runner
 Annota le tue classi collection con `@collection` e scegli un campo `Id`.
 
 ```dart
-part 'user.g.dart'
+part 'user.g.dart';
 
 @collection
 class User {

--- a/docs/docs/it/tutorials/quickstart.md
+++ b/docs/docs/it/tutorials/quickstart.md
@@ -22,7 +22,10 @@ flutter pub add -d isar_generator build_runner
 Annota le tue classi collection con `@collection` e scegli un campo `Id`.
 
 ```dart
-part 'email.g.dart'
+part 'user.g.dart'
+
+@collection
+class User {
   Id id = Isar.autoIncrement; // puoi anche usare id = null per incrementare automaticamente
 
   String? name;
@@ -52,7 +55,7 @@ flutter pub run build_runner build
 Apri una nuova istanza Isar e passa tutti i tuoi schemi di raccolte. Facoltativamente, puoi specificare un nome di istanza e una directory.
 
 ```dart
-final isar = await Isar.open([EmailSchema]);
+final isar = await Isar.open([UserSchema]);
 ```
 
 ## 5. Scrivi e leggi

--- a/docs/docs/ja/tutorials/quickstart.md
+++ b/docs/docs/ja/tutorials/quickstart.md
@@ -23,7 +23,7 @@ flutter pub add -d isar_generator build_runner
 あなたの使用するコレクションクラスに `@collection` でアノテーションを付け、`Id` フィールドを設定します。
 
 ```dart
-part 'email.g.dart';
+part 'user.g.dart';
 
 @collection
 class User {

--- a/docs/docs/ja/tutorials/quickstart.md
+++ b/docs/docs/ja/tutorials/quickstart.md
@@ -56,7 +56,7 @@ flutter pub run build_runner build
 新規のIsarインスタンスを開き、コレクションのスキーマを渡します。必要に応じて、インスタンス名とディレクトリを指定することができます。
 
 ```dart
-final isar = await Isar.open([EmailSchema]);
+final isar = await Isar.open([UserSchema]);
 ```
 
 ## 5. 書き込みと読み込み

--- a/docs/docs/pt/tutorials/quickstart.md
+++ b/docs/docs/pt/tutorials/quickstart.md
@@ -55,7 +55,7 @@ flutter pub run build_runner build
 Abra uma nova instância Isar e passe todos os seus esquemas de coleção. Opcionalmente, você pode especificar um nome de instância e um diretório.
 
 ```dart
-final isar = await Isar.open([EmailSchema]);
+final isar = await Isar.open([UserSchema]);
 ```
 
 ## 5. Escrever e ler

--- a/docs/docs/pt/tutorials/quickstart.md
+++ b/docs/docs/pt/tutorials/quickstart.md
@@ -22,7 +22,7 @@ flutter pub add -d isar_generator build_runner
 Anote suas coleções de classes com `@collection` e escolha um campo 'Id'.
 
 ```dart
-part 'email.g.dart';
+part 'user.g.dart';
 
 @collection
 class User {

--- a/docs/docs/tutorials/quickstart.md
+++ b/docs/docs/tutorials/quickstart.md
@@ -55,7 +55,7 @@ flutter pub run build_runner build
 Open a new Isar instance and pass all of your collection schemas. Optionally you can specify an instance name and directory.
 
 ```dart
-final isar = await Isar.open([EmailSchema]);
+final isar = await Isar.open([UserSchema]);
 ```
 
 ## 5. Write and read

--- a/docs/docs/tutorials/quickstart.md
+++ b/docs/docs/tutorials/quickstart.md
@@ -22,7 +22,7 @@ flutter pub add -d isar_generator build_runner
 Annotate your collection classes with `@collection` and choose an `Id` field.
 
 ```dart
-part 'email.g.dart';
+part 'user.g.dart';
 
 @collection
 class User {

--- a/docs/docs/ur/tutorials/quickstart.md
+++ b/docs/docs/ur/tutorials/quickstart.md
@@ -52,7 +52,7 @@ flutter pub run build_runner build
    ایک نیا ای زار مثال کھولیں اور اپنے تمام کلیکشن اسکیموں کو پاس کریں۔ اختیاری طور پر آپ مثال کا نام اور ڈائریکٹری بتا سکتے ہیں۔
 
 ```dart
-final isar = await Isar.open([EmailSchema]);
+final isar = await Isar.open([UserSchema]);
 ```
 
 ## 5. لکھیں اور پڑھیں

--- a/docs/docs/ur/tutorials/quickstart.md
+++ b/docs/docs/ur/tutorials/quickstart.md
@@ -20,7 +20,7 @@ flutter pub add -d isar_generator build_runner
 اپنی کلیکشن کلاسز کو "کلیکشن@" کے ساتھ تشریح کریں اورایک "آئی ڈی@" فیلڈ کا انتخاب کریں۔
 
 ```dart
-part 'email.g.dart';
+part 'user.g.dart';
 
 @collection
 class User {

--- a/docs/docs/zh/tutorials/quickstart.md
+++ b/docs/docs/zh/tutorials/quickstart.md
@@ -22,7 +22,7 @@ flutter pub add -d isar_generator build_runner
 用 `@collection` 给你的 Collection 类添加注解，并指定一个 `Id` 字段。
 
 ```dart
-part 'email.g.dart';
+part 'user.g.dart';
 
 @collection
 class User {

--- a/docs/docs/zh/tutorials/quickstart.md
+++ b/docs/docs/zh/tutorials/quickstart.md
@@ -55,7 +55,7 @@ flutter pub run build_runner build
 创建一个新的 Isar 实例，并将你想保存到 Isar 的所有 collection 的 schema（它在上一步由 Isar Generator 根据你定义的 collection 自动生成） 作为参数传入。你还可以指定实例的名称以及它所存储数据的文件路径。
 
 ```dart
-final isar = await Isar.open([EmailSchema]);
+final isar = await Isar.open([UserSchema]);
 ```
 
 ## 5. 读写操作


### PR DESCRIPTION
Fixed some errors in the documentation

1. Changed the file name generated by the `User class` to `user.g.part`.
2. Changed the scheme name. `EmailSchema` → `UserScheme`.
3. Added class definition that lacked description.

