### PR TITLE
Added `SafeIntId` alternative to "String ids" recipe.

### DIFF
--- a/docs/docs/recipes/string_ids.md
+++ b/docs/docs/recipes/string_ids.md
@@ -52,3 +52,32 @@ If you choose a different hash function, ensure it returns a 64-bit int and avoi
 :::warning
 Avoid using `string.hashCode` because it is not guaranteed to be stable across different platforms and versions of Dart.
 :::
+
+## SafeIntId
+
+You may also find that you don't need String id - you just cannot use auto-increment int id, e.g. when a user creates new objects on multiple devices in an offline-first app which syncs in the background.
+
+In this case please consider using [SafeIntId](https://pub.dev/packages/safe_int_id) designed for Isar.
+
+* [Check](https://pub.dev/packages/safe_int_id#design-and-usage) if it fits your case.
+* [Install and import](https://pub.dev/packages/safe_int_id/install) it.
+* Configure your collection id to be `int`, neither `null` nor `Isar.autoIncrement`:
+    * Isar 3:
+        ```dart
+        @collection
+        class Item {
+          late Id id;
+        }
+        ```
+    * Isar 2.5.0:
+        ```dart
+        @Collection()
+        class Item {
+          @Id()
+          late int id;
+        }
+        ```
+* Create an object and set its id:
+    ```dart
+    final newItem = Item()..id = safeIntId.getId();
+    ```


### PR DESCRIPTION
Hi, I've designed https://pub.dev/packages/safe_int_id for Isar when auto-increment is not an option and String id is an overkill.

Example use case: a user creates new objects on multiple devices in an offline-first app which syncs in the background.

Please review my idea and consider adding it as an alternative to the "String ids" recipe.

New section for this recipe is attached.