### PR TITLE
updated docs according to the new breaking change in Isar.open()

### DIFF
--- a/docs/docs/crud.md
+++ b/docs/docs/crud.md
@@ -13,7 +13,11 @@ Before you can do anything, we need an Isar instance. Each instance requires a d
 Provide all the schemas you want to use with the Isar instance. If you open multiple instances, you still have to provide the same schemas to each instance.
 
 ```dart
-final isar = await Isar.open([RecipeSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [RecipeSchema],
+  directory: dir.path,
+);
 ```
 
 You can use the default config or provide some of the following parameters:

--- a/docs/docs/de/crud.md
+++ b/docs/docs/de/crud.md
@@ -13,7 +13,11 @@ Als Erstes benötigen wir eine Isar Instanz. Jede Instanz erfordert einen Ordner
 Gib alle Schemas an, die du mit der Isar-Instanz verwenden möchtest. Wenn du mehrere Instanzen öffnest, musst du trotzdem jeder Instanz die gleichen Schemas mitgeben.
 
 ```dart
-final isar = await Isar.open([RecipeSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [RecipeSchema],
+  directory: dir.path,
+);
 ```
 
 Du kannst die Standardkonfiguration verwenden oder einige der folgenden Parameter setzen:

--- a/docs/docs/de/recipes/data_migration.md
+++ b/docs/docs/de/recipes/data_migration.md
@@ -47,7 +47,12 @@ import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
-  final isar = await Isar.open([UserSchema]);
+  final dir = await getApplicationDocumentsDirectory();
+  
+  final isar = await Isar.open(
+    [UserSchema],
+    directory: dir.path,
+  );
 
   await performMigrationIfNeeded(isar);
 

--- a/docs/docs/de/recipes/multi_isolate.md
+++ b/docs/docs/de/recipes/multi_isolate.md
@@ -29,8 +29,11 @@ Stelle sicher, dass du die gleichen Schemas wie im zentralen Isolate zur Verfüg
 ```dart
 void main() {
   // Isar im UI-Isolate öffnen
+  final dir = await getApplicationDocumentsDirectory();
+
   final isar = await Isar.open(
-    [MessageSchema]
+    [MessageSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 
@@ -52,8 +55,11 @@ void main() {
 // Funktion, die im neuen Isolate ausgeführt werden soll
 Future createDummyMessages(int count) async {
   // Wir benötigen hier keinen Pfad, weil die Instanz schon offen ist
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
     [PostSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 

--- a/docs/docs/de/tutorials/quickstart.md
+++ b/docs/docs/de/tutorials/quickstart.md
@@ -55,7 +55,11 @@ flutter pub run build_runner build
 Öffne eine neue Isar-Instanz und übergebe alle Collection-Schemata. Optional kannst du einen Instanznamen und ein Verzeichnis angeben.
 
 ```dart
-final isar = await Isar.open([UserSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [UserSchema],
+  directory: dir.path,
+);
 ```
 
 ## 5. Schreiben und lesen

--- a/docs/docs/es/crud.md
+++ b/docs/docs/es/crud.md
@@ -13,7 +13,11 @@ Antes de hacer nada, necesitamos una instancia Isar. Cada instancia requiere un 
 Provee todos los esquemas que quieras usar con la instancia Isar. Si abres múltiples instancias, aún tienes que proveer todos los esquemas a cada instancia.
 
 ```dart
-final isar = await Isar.open([ContactSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [ContactSchema],
+  directory: dir.path,
+);
 ```
 
 Puedes usar la configuración por defecto o proveer algunos de los siguientes parámetros:

--- a/docs/docs/es/recipes/data_migration.md
+++ b/docs/docs/es/recipes/data_migration.md
@@ -49,7 +49,12 @@ import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
-  final isar = await Isar.open([UserSchema]);
+  final dir = await getApplicationDocumentsDirectory();
+  
+  final isar = await Isar.open(
+    [UserSchema],
+    directory: dir.path,
+  );
 
   await performMigrationIfNeeded(isar);
 

--- a/docs/docs/es/recipes/multi_isolate.md
+++ b/docs/docs/es/recipes/multi_isolate.md
@@ -29,8 +29,11 @@ Asegúrate de proveer los mismos esquemas que en el isolate principal. De lo con
 ```dart
 void main() {
   // Open Isar in the UI isolate
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
-    [MessageSchema]
+    [MessageSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 
@@ -52,8 +55,11 @@ void main() {
 // function that will be executed in the new isolate
 Future createDummyMessages(int count) async {
   // we don't need the path here because the instance is already open
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
     [PostSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 

--- a/docs/docs/es/tutorials/quickstart.md
+++ b/docs/docs/es/tutorials/quickstart.md
@@ -55,7 +55,11 @@ flutter pub run build_runner build
 Abre una nueva instalcia Isar y pásale todos los esquemas de tu colección. Opcionalmente puedes especificar un nombre para la instancia y un directorio.
 
 ```dart
-final isar = await Isar.open([UserSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [UserSchema],
+  directory: dir.path,
+);
 ```
 
 ## 5. Lee y escribe

--- a/docs/docs/fr/crud.md
+++ b/docs/docs/fr/crud.md
@@ -13,7 +13,11 @@ Avant de pouvoir faire quoi que ce soit, nous avons besoin d'une instance Isar. 
 Fournissez tous les schémas que vous souhaitez utiliser avec l'instance Isar. Si nous ouvrons plusieurs instances, nous devons toujours fournir les mêmes schémas à chaque instance.
 
 ```dart
-final isar = await Isar.open([ContactSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [ContactSchema],
+  directory: dir.path,
+);
 ```
 
 Nous pouvons utiliser la configuration par défaut ou fournir certains des paramètres suivants:

--- a/docs/docs/fr/recipes/data_migration.md
+++ b/docs/docs/fr/recipes/data_migration.md
@@ -47,7 +47,12 @@ import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
-  final isar = await Isar.open([UserSchema]);
+  final dir = await getApplicationDocumentsDirectory();
+  
+  final isar = await Isar.open(
+    [UserSchema],
+    directory: dir.path,
+  );
 
   await performMigrationIfNeeded(isar);
 

--- a/docs/docs/fr/recipes/multi_isolate.md
+++ b/docs/docs/fr/recipes/multi_isolate.md
@@ -29,8 +29,11 @@ Assurez-vous de fournir les mêmes schémas que dans l'isolat principal. Sinon, 
 ```dart
 void main() {
   // Ouvre Isar dans l'isolat de l'interface utilisateur
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
-    [MessageSchema]
+    [MessageSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 
@@ -52,8 +55,11 @@ void main() {
 // Fonction qui sera exécutée dans le nouvel isolat
 Future createDummyMessages(int count) async {
   // Nous n'avons pas besoin du chemin du dossier ici étant donné que l'instance est déjà ouverte.
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
     [PostSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 

--- a/docs/docs/fr/tutorials/quickstart.md
+++ b/docs/docs/fr/tutorials/quickstart.md
@@ -55,7 +55,11 @@ flutter pub run build_runner build
 Ouvrez une nouvelle instance d'Isar et passez tous vos schémas de collection. En option, vous pouvez spécifier un nom d'instance et un dossier.
 
 ```dart
-final isar = await Isar.open([UserSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [UserSchema],
+  directory: dir.path,
+);
 ```
 
 ## 5. Écriture et lecture

--- a/docs/docs/it/crud.md
+++ b/docs/docs/it/crud.md
@@ -13,7 +13,11 @@ Prima che tu possa fare qualsiasi cosa, abbiamo bisogno di un'istanza Isar. Ogni
 Fornisci tutti gli schemi che desideri utilizzare con l'istanza Isar. Se apri più istanze, devi comunque fornire gli stessi schemi a ciascuna istanza.
 
 ```dart
-final isar = await Isar.open([ContactSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [ContactSchema],
+  directory: dir.path,
+);
 ```
 
 È possibile utilizzare la configurazione predefinita o fornire alcuni dei seguenti parametri:

--- a/docs/docs/it/recipes/data_migration.md
+++ b/docs/docs/it/recipes/data_migration.md
@@ -47,7 +47,12 @@ import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
-  final isar = await Isar.open([UserSchema]);
+  final dir = await getApplicationDocumentsDirectory();
+  
+  final isar = await Isar.open(
+    [UserSchema],
+    directory: dir.path,
+  );
 
   await performMigrationIfNeeded(isar);
 

--- a/docs/docs/it/recipes/multi_isolate.md
+++ b/docs/docs/it/recipes/multi_isolate.md
@@ -29,8 +29,11 @@ Assicurati di fornire gli stessi schemi dell'isolate principale. In caso contrar
 ```dart
 void main() {
   // Open Isar in the UI isolate
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
-    [MessageSchema]
+    [MessageSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 
@@ -52,8 +55,11 @@ void main() {
 // function that will be executed in the new isolate
 Future createDummyMessages(int count) async {
   // we don't need the path here because the instance is already open
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
     [PostSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 

--- a/docs/docs/it/tutorials/quickstart.md
+++ b/docs/docs/it/tutorials/quickstart.md
@@ -55,7 +55,11 @@ flutter pub run build_runner build
 Apri una nuova istanza Isar e passa tutti i tuoi schemi di raccolte. Facoltativamente, puoi specificare un nome di istanza e una directory.
 
 ```dart
-final isar = await Isar.open([UserSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [UserSchema],
+  directory: dir.path,
+);
 ```
 
 ## 5. Scrivi e leggi

--- a/docs/docs/ja/crud.md
+++ b/docs/docs/ja/crud.md
@@ -13,7 +13,11 @@ title: CRUD操作
 Isarインスタンスで使用したいすべてのスキーマを指定します。複数のインスタンスを開いている場合でも、それぞれのインスタンスに同じスキーマを与える必要があります。
 
 ```dart
-final isar = await Isar.open([ContactSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [ContactSchema],
+  directory: dir.path,
+);
 ```
 
 加えて、デフォルト設定を使用するか、もしくは以下のいくつかのパラメータを指定することができます:

--- a/docs/docs/ja/recipes/data_migration.md
+++ b/docs/docs/ja/recipes/data_migration.md
@@ -47,7 +47,12 @@ import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
-  final isar = await Isar.open([UserSchema]);
+  final dir = await getApplicationDocumentsDirectory();
+  
+  final isar = await Isar.open(
+    [UserSchema],
+    directory: dir.path,
+  );
 
   await performMigrationIfNeeded(isar);
 

--- a/docs/docs/ja/recipes/multi_isolate.md
+++ b/docs/docs/ja/recipes/multi_isolate.md
@@ -29,8 +29,11 @@ Isarのトランザクションは、同じアイソレートで実行されて�
 ```dart
 void main() {
   // UIアイソレートでIsarを開く
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
-    [MessageSchema]
+    [MessageSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 
@@ -52,8 +55,11 @@ void main() {
 // 新しいアイソレート内で実行される関数
 Future createDummyMessages(int count) async {
   // インスタンスはすでに開かれているので、ここではPathは必要ありません。
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
     [PostSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 

--- a/docs/docs/ja/tutorials/quickstart.md
+++ b/docs/docs/ja/tutorials/quickstart.md
@@ -56,7 +56,11 @@ flutter pub run build_runner build
 新規のIsarインスタンスを開き、コレクションのスキーマを渡します。必要に応じて、インスタンス名とディレクトリを指定することができます。
 
 ```dart
-final isar = await Isar.open([UserSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [UserSchema],
+  directory: dir.path,
+);
 ```
 
 ## 5. 書き込みと読み込み

--- a/docs/docs/ko/crud.md
+++ b/docs/docs/ko/crud.md
@@ -13,7 +13,11 @@ title: CRUD 조작
 Isar 인스턴스에서 사용하고 싶은 모든 스키마를 지정합니다. 여러 인스턴스를 열고 있는 경우에도 각각의 인스턴스에 동일한 스키마를 부여해야 합니다.
 
 ```dart
-final isar = await Isar.open([RecipeSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [RecipeSchema],
+  directory: dir.path,
+);
 ```
 
 기본 구성을 사용하거나 다음 매개 변수 중 일부를 제공할 수 있습니다:

--- a/docs/docs/ko/recipes/data_migration.md
+++ b/docs/docs/ko/recipes/data_migration.md
@@ -49,7 +49,12 @@ import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
-  final isar = await Isar.open([UserSchema]);
+  final dir = await getApplicationDocumentsDirectory();
+  
+  final isar = await Isar.open(
+    [UserSchema],
+    directory: dir.path,
+  );
 
   await performMigrationIfNeeded(isar);
 

--- a/docs/docs/ko/recipes/multi_isolate.md
+++ b/docs/docs/ko/recipes/multi_isolate.md
@@ -29,8 +29,11 @@ Make sure to provide the same schemas as in the main isolate. Otherwise, you wil
 ```dart
 void main() {
   // Open Isar in the UI isolate
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
-    [MessageSchema]
+    [MessageSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 
@@ -52,8 +55,11 @@ void main() {
 // function that will be executed in the new isolate
 Future createDummyMessages(int count) async {
   // we don't need the path here because the instance is already open
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
     [PostSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 

--- a/docs/docs/ko/tutorials/quickstart.md
+++ b/docs/docs/ko/tutorials/quickstart.md
@@ -55,7 +55,11 @@ flutter pub run build_runner build
 새 Isar 인스턴스를 열고 모든 컬렉션 스키마를 전달합니다. 선택적으로 인스턴스 이름과 디렉토리를 지정할 수도 있습니다.
 
 ```dart
-final isar = await Isar.open([EmailSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [EmailSchema],
+  directory: dir.path,
+);
 ```
 
 ## 5. 읽기와 쓰기

--- a/docs/docs/pt/crud.md
+++ b/docs/docs/pt/crud.md
@@ -13,7 +13,11 @@ Antes que você possa fazer qualquer coisa, precisamos de uma instância Isar. C
 Forneça todos os esquemas que deseja usar com a instância Isar. Se você abrir várias instâncias, ainda precisará fornecer os mesmos esquemas para cada instância.
 
 ```dart
-final isar = await Isar.open([RecipeSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [RecipeSchema],
+  directory: dir.path,
+);
 ```
 
 Você pode usar a configuração padrão ou fornecer alguns dos seguintes parâmetros:

--- a/docs/docs/pt/tutorials/quickstart.md
+++ b/docs/docs/pt/tutorials/quickstart.md
@@ -55,7 +55,11 @@ flutter pub run build_runner build
 Abra uma nova instância Isar e passe todos os seus esquemas de coleção. Opcionalmente, você pode especificar um nome de instância e um diretório.
 
 ```dart
-final isar = await Isar.open([UserSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [UserSchema],
+  directory: dir.path,
+);
 ```
 
 ## 5. Escrever e ler

--- a/docs/docs/recipes/data_migration.md
+++ b/docs/docs/recipes/data_migration.md
@@ -47,7 +47,12 @@ import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
-  final isar = await Isar.open([UserSchema]);
+  final dir = await getApplicationDocumentsDirectory();
+  
+  final isar = await Isar.open(
+    [UserSchema],
+    directory: dir.path,
+  );
 
   await performMigrationIfNeeded(isar);
 

--- a/docs/docs/recipes/multi_isolate.md
+++ b/docs/docs/recipes/multi_isolate.md
@@ -29,8 +29,11 @@ Make sure to provide the same schemas as in the main isolate. Otherwise, you wil
 ```dart
 void main() {
   // Open Isar in the UI isolate
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
-    [MessageSchema]
+    [MessageSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 
@@ -52,8 +55,11 @@ void main() {
 // function that will be executed in the new isolate
 Future createDummyMessages(int count) async {
   // we don't need the path here because the instance is already open
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
     [PostSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 

--- a/docs/docs/tutorials/quickstart.md
+++ b/docs/docs/tutorials/quickstart.md
@@ -55,7 +55,11 @@ flutter pub run build_runner build
 Open a new Isar instance and pass all of your collection schemas. Optionally you can specify an instance name and directory.
 
 ```dart
-final isar = await Isar.open([UserSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [UserSchema],
+  directory: dir.path,
+);
 ```
 
 ## 5. Write and read

--- a/docs/docs/ur/crud.md
+++ b/docs/docs/ur/crud.md
@@ -13,7 +13,11 @@ title: بنائیں، پڑھیں، اپ ڈیٹ کریں، حذف کریں
 وہ تمام اسکیمے فراہم کریں جو آپ ای زار مثال کے ساتھ استعمال کرنا چاہتے ہیں۔ اگر آپ متعدد مثالوں کو کھولتے ہیں، تو آپ کو اب بھی ہر ایک مثال کے لیے ایک ہی اسکیما فراہم کرنا ہوں گی۔
 
 ```dart
-final isar = await Isar.open([RecipeSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [RecipeSchema],
+  directory: dir.path,
+);
 ```
 آپ پہلے سے طے شدہ تشکیل استعمال کرسکتے ہیں یا درج ذیل میں سے کچھ پیرامیٹرز فراہم کرسکتے ہیں۔
 

--- a/docs/docs/ur/recipes/data_migration.md
+++ b/docs/docs/ur/recipes/data_migration.md
@@ -49,7 +49,12 @@ import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
-  final isar = await Isar.open([UserSchema]);
+  final dir = await getApplicationDocumentsDirectory();
+  
+  final isar = await Isar.open(
+    [UserSchema],
+    directory: dir.path,
+  );
 
   await performMigrationIfNeeded(isar);
 

--- a/docs/docs/ur/recipes/multi_isolate.md
+++ b/docs/docs/ur/recipes/multi_isolate.md
@@ -29,8 +29,11 @@ Make sure to provide the same schemas as in the main isolate. Otherwise, you wil
 ```dart
 void main() {
   // Open Isar in the UI isolate
+  final dir = await getApplicationDocumentsDirectory();
+
   final isar = await Isar.open(
-    [MessageSchema]
+    [MessageSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 
@@ -52,8 +55,11 @@ void main() {
 // function that will be executed in the new isolate
 Future createDummyMessages(int count) async {
   // we don't need the path here because the instance is already open
+  final dir = await getApplicationDocumentsDirectory();
+
   final isar = await Isar.open(
     [PostSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 

--- a/docs/docs/ur/tutorials/quickstart.md
+++ b/docs/docs/ur/tutorials/quickstart.md
@@ -52,7 +52,11 @@ flutter pub run build_runner build
    ایک نیا ای زار مثال کھولیں اور اپنے تمام کلیکشن اسکیموں کو پاس کریں۔ اختیاری طور پر آپ مثال کا نام اور ڈائریکٹری بتا سکتے ہیں۔
 
 ```dart
-final isar = await Isar.open([UserSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [UserSchema],
+  directory: dir.path,
+);
 ```
 
 ## 5. لکھیں اور پڑھیں

--- a/docs/docs/zh/crud.md
+++ b/docs/docs/zh/crud.md
@@ -13,7 +13,11 @@ title: 增删改查
 将你想要使用的所有 Collection 的 Schema 作为参数传入到创建实例的方法中。如果你有多个实例，你仍然需要给每个实例配置相同的 Schema（即各个实例的 Schema 必须一致）。
 
 ```dart
-final isar = await Isar.open([RecipeSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [RecipeSchema],
+  directory: dir.path,
+);
 ```
 
 你可以使用默认配置，也可以根据下表修改参数：

--- a/docs/docs/zh/recipes/data_migration.md
+++ b/docs/docs/zh/recipes/data_migration.md
@@ -49,7 +49,12 @@ import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
-  final isar = await Isar.open([UserSchema]);
+  final dir = await getApplicationDocumentsDirectory();
+  
+  final isar = await Isar.open(
+    [UserSchema],
+    directory: dir.path,
+  );
 
   await performMigrationIfNeeded(isar);
 

--- a/docs/docs/zh/recipes/multi_isolate.md
+++ b/docs/docs/zh/recipes/multi_isolate.md
@@ -29,8 +29,11 @@ Isar 事务即使在单 isolate 环境中也是并行运行的。但有些情况
 ```dart
 void main() {
   // 在 UI isolate 中创建 Isar 实例
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
-    [MessageSchema]
+    [MessageSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 
@@ -52,8 +55,11 @@ void main() {
 // 函数将会在新的 isolate 中被执行
 Future createDummyMessages(int count) async {
   // 我们没必要在此指定路径，因为它已经被创建好了
+  final dir = await getApplicationDocumentsDirectory();
+  
   final isar = await Isar.open(
     [PostSchema],
+    directory: dir.path,
     name: 'myInstance',
   );
 

--- a/docs/docs/zh/tutorials/quickstart.md
+++ b/docs/docs/zh/tutorials/quickstart.md
@@ -55,7 +55,11 @@ flutter pub run build_runner build
 创建一个新的 Isar 实例，并将你想保存到 Isar 的所有 collection 的 schema（它在上一步由 Isar Generator 根据你定义的 collection 自动生成） 作为参数传入。你还可以指定实例的名称以及它所存储数据的文件路径。
 
 ```dart
-final isar = await Isar.open([UserSchema]);
+final dir = await getApplicationDocumentsDirectory();
+final isar = await Isar.open(
+  [UserSchema],
+  directory: dir.path,
+);
 ```
 
 ## 5. 读写操作

--- a/packages/isar/README.md
+++ b/packages/isar/README.md
@@ -112,7 +112,7 @@ enum Status {
 final dir = await getApplicationDocumentsDirectory();
 final isar = await Isar.open(
   [EmailSchema],
-  directory: dir,
+  directory: dir.path,
 );
 ```
 


### PR DESCRIPTION
Updated Isar.open() to use the directory parameter for all translations on crud.md, data_migration.md, multi_isolate.md and quickstart.md. Also updated the README.md.