### PR TITLE
Added the possibility of customizing the constructor used to Deserialize Isar Collections

### DIFF
--- a/packages/isar/lib/src/annotations/collection.dart
+++ b/packages/isar/lib/src/annotations/collection.dart
@@ -11,6 +11,7 @@ class Collection {
     this.inheritance = true,
     this.accessor,
     this.ignore = const {},
+    this.constructor,
   });
 
   /// Should properties and accessors of parent classes and mixins be included?
@@ -31,4 +32,8 @@ class Collection {
 
   /// A list of properties or getter names that Isar should ignore.
   final Set<String> ignore;
+
+  /// The name for the constructor that Isar should use.
+  /// If null, the first unnamed constructor will be used.
+  final String? constructor;
 }

--- a/packages/isar_generator/lib/src/code_gen/type_adapter_generator.dart
+++ b/packages/isar_generator/lib/src/code_gen/type_adapter_generator.dart
@@ -242,6 +242,10 @@ String generateSerialize(ObjectInfo object) {
 }
 
 String generateDeserialize(ObjectInfo object) {
+  final constructor = (object.constructor != null && object.constructor!.isNotEmpty)
+      ? '${object.dartName}.${object.constructor!}'
+      : object.dartName;
+
   var code = '''
     ${object.dartName} ${object.deserializeName}(
       Id id,
@@ -249,7 +253,7 @@ String generateDeserialize(ObjectInfo object) {
       List<int> offsets,
       Map<Type, List<int>> allOffsets,
     ) {
-      final object = ${object.dartName}(''';
+      final object = $constructor(''';
 
   final propertiesByMode =
       object.properties.groupBy((ObjectProperty p) => p.deserialize);

--- a/packages/isar_generator/lib/src/helper.dart
+++ b/packages/isar_generator/lib/src/helper.dart
@@ -140,6 +140,7 @@ extension ElementX on Element {
           .toSetValue()!
           .map((e) => e.toStringValue()!)
           .toSet(),
+      constructor: ann.getField('constructor')!.toStringValue()
     );
   }
 
@@ -171,6 +172,8 @@ extension ElementX on Element {
           .toSet(),
     );
   }
+
+  String? get collectionConstructor => collectionAnnotation?.constructor;
 }
 
 void checkIsarName(String name, Element element) {

--- a/packages/isar_generator/lib/src/isar_analyzer.dart
+++ b/packages/isar_generator/lib/src/isar_analyzer.dart
@@ -129,7 +129,7 @@ class IsarAnalyzer {
       }
     }else{
       constructor = modelClass.constructors
-          .firstOrNullWhere((ConstructorElement c) => c.displayName == customConstructorName);
+          .firstOrNullWhere((ConstructorElement c) => c.name == customConstructorName);
       if (constructor == null) {
         err('Class needs a constructor with name $customConstructorName, as specified by the @Collection annotation.', modelClass);
       }

--- a/packages/isar_generator/lib/src/isar_analyzer.dart
+++ b/packages/isar_generator/lib/src/isar_analyzer.dart
@@ -55,6 +55,7 @@ class IsarAnalyzer {
       embeddedDartNames: _getEmbeddedDartNames(element),
       indexes: indexes,
       links: links,
+      constructor: constructor.name,
     );
   }
 
@@ -117,10 +118,21 @@ class IsarAnalyzer {
       err('Class must be public.', modelClass);
     }
 
-    final constructor = modelClass.constructors
-        .firstOrNullWhere((ConstructorElement c) => c.periodOffset == null);
-    if (constructor == null) {
-      err('Class needs an unnamed constructor.', modelClass);
+    final customConstructorName = modelClass.collectionConstructor;
+    
+    final ConstructorElement? constructor;
+    if(customConstructorName == null){
+      constructor = modelClass.constructors
+          .firstOrNullWhere((ConstructorElement c) => c.periodOffset == null);
+      if (constructor == null) {
+        err('Class needs an unnamed constructor.', modelClass);
+      }
+    }else{
+      constructor = modelClass.constructors
+          .firstOrNullWhere((ConstructorElement c) => c.displayName == customConstructorName);
+      if (constructor == null) {
+        err('Class needs a constructor with name $customConstructorName, as specified by the @Collection annotation.', modelClass);
+      }
     }
 
     final hasCollectionSupertype = modelClass.allSupertypes.any((type) {

--- a/packages/isar_generator/lib/src/object_info.dart
+++ b/packages/isar_generator/lib/src/object_info.dart
@@ -15,6 +15,7 @@ class ObjectInfo {
     this.embeddedDartNames = const {},
     this.indexes = const [],
     this.links = const [],
+    this.constructor,
   }) {
     this.properties = properties.sortedBy((e) => e.isarName).toList();
   }
@@ -22,6 +23,7 @@ class ObjectInfo {
   final String dartName;
   final String isarName;
   final String? accessor;
+  final String? constructor;
   late final List<ObjectProperty> properties;
   final Map<String, String> embeddedDartNames;
   final List<ObjectIndex> indexes;


### PR DESCRIPTION
I updated the `Collection` annotation adding support for an additional field called `constructor`. This additions allow to deserialize freezed classes where fields have been annotated with `@ignore`. I tested the implementation with different use case scenarios and it worked fine, but I have never worked with code generator before so there's a chance I have missed something.

### An Example:
From [this Discussion](https://github.com/isar/isar/discussions/518), I saw that it is possible to use freezed and isar together to create a collection. 

The example they make is the following:
```
@freezed
@Collection(ignore: {'copyWith'})
class Expense with _$Expense {
  const Expense._();

  @JsonSerializable()
  const factory Expense({
    required int id,
    required DateTime creationDate,
    required int amount,
    @JsonKey(name: 'name') required String note,
  }) = _Expense;

  @override
  // ignore: recursive_getters
  Id get id => id;

  factory Expense.fromJson(Map<String, dynamic> json) =>
      _$ExpenseFromJson(json);
}
```


However, if for some reason I would like to ignore the field `amount` when writing in the collection and I add the `@ignore` annotation, isar throws an error while building with build_runner. The error I face is that the `amount` field in the `Expense` constructor does not corrispond to a property, as It's ignored but still required in the constructor.

For this reason, I think the capability of using another constructor other than the unnamed one might be useful in this scenario.
With the proposed changes, a possible implementation could be the following:

```
@freezed
@Collection(ignore: {'copyWith'}, constructor: "isar")
class Expense with _$Expense {
  const Expense._();

  @JsonSerializable()
  const factory Expense({
    required int id,
    required DateTime creationDate,
    @ignore required int amount,
    @JsonKey(name: 'name') required String note,
  }) = _Expense;

  /// The Constructor for isar.
  /// Since we are ignoring the amount field, we need to create a constructor for isar which handles it.
  factory Expense.isar({
    required int id,
    required DateTime creationDate,
    required String note,
  }) =>
      Expense(
        id: id,
        creationDate: creationDate,
        amount: 0,
        note: note,
      );

  Id get isarId => id;

  factory Expense.fromJson(Map<String, dynamic> json) => _$ExpenseFromJson(json);
}

```
