### PR TITLE
String-to-index property mapper

### DIFF
--- a/packages/isar/lib/src/generator/code_gen/schema_property_mapper_generator.dart
+++ b/packages/isar/lib/src/generator/code_gen/schema_property_mapper_generator.dart
@@ -1,0 +1,9 @@
+part of isar_generator;
+
+String _generatePropertyMapper(ObjectInfo object) {
+  var index = 0;
+  return '''
+    const ${object.dartName.capitalize()}PropertyMapper = <String, int>{
+      ${object.properties.map((e) => '"${e.dartName}":${index++}').join(",")}
+    };''';
+}

--- a/packages/isar/lib/src/generator/code_gen/schema_property_mapper_generator.dart
+++ b/packages/isar/lib/src/generator/code_gen/schema_property_mapper_generator.dart
@@ -1,7 +1,7 @@
 part of isar_generator;
 
 String _generatePropertyMapper(ObjectInfo object) {
-  var index = 0;
+  var index = 1;
   return '''
     const ${object.dartName.capitalize()}PropertyMapper = <String, int>{
       ${object.properties.map((e) => '"${e.dartName}":${index++}').join(",")}

--- a/packages/isar/lib/src/generator/collection_generator.dart
+++ b/packages/isar/lib/src/generator/collection_generator.dart
@@ -16,15 +16,19 @@ const _ignoreLints = [
 ];
 
 class _IsarCollectionGenerator extends GeneratorForAnnotation<Collection> {
+  _IsarCollectionGenerator(this.config);
+
+  final Map<String, dynamic> config;
+
   @override
   Future<String> generateForAnnotatedElement(
     Element element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
+    final generatePropertyMapper = config['propertyMapper'] == true;
     final object = _IsarAnalyzer().analyzeCollection(element);
-    final idType =
-        object.idProperty!.type == IsarType.string ? 'String' : 'int';
+    final idType = object.idProperty!.type == IsarType.string ? 'String' : 'int';
     return '''
       // coverage:ignore-file
       // ignore_for_file: ${_ignoreLints.join(', ')}
@@ -35,6 +39,8 @@ class _IsarCollectionGenerator extends GeneratorForAnnotation<Collection> {
       }
 
       ${_generateSchema(object)}
+
+      ${generatePropertyMapper ? _generatePropertyMapper(object) : ''}
 
       ${_generateSerialize(object)}
 
@@ -60,12 +66,17 @@ class _IsarCollectionGenerator extends GeneratorForAnnotation<Collection> {
 }
 
 class _IsarEmbeddedGenerator extends GeneratorForAnnotation<Embedded> {
+  _IsarEmbeddedGenerator(this.config);
+
+  final Map<String, dynamic> config;
+
   @override
   Future<String> generateForAnnotatedElement(
     Element element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
+    final generatePropertyMapper = config['propertyMapper'] == true;
     final object = _IsarAnalyzer().analyzeEmbedded(element);
     return '''
       // coverage:ignore-file
@@ -73,6 +84,8 @@ class _IsarEmbeddedGenerator extends GeneratorForAnnotation<Embedded> {
       // ignore_for_file: type=lint
 
       ${_generateSchema(object)}
+
+      ${generatePropertyMapper ? _generatePropertyMapper(object) : ''}
 
       ${_generateSerialize(object)}
 

--- a/packages/isar/lib/src/generator/isar_generator.dart
+++ b/packages/isar/lib/src/generator/isar_generator.dart
@@ -11,6 +11,7 @@ import 'package:isar/isar.dart';
 import 'package:source_gen/source_gen.dart';
 
 part 'code_gen/collection_schema_generator.dart';
+part 'code_gen/schema_property_mapper_generator.dart';
 part 'code_gen/deserialize_generator.dart';
 part 'code_gen/enum_maps_generator.dart';
 part 'code_gen/query_distinct_by_generator.dart';
@@ -32,8 +33,8 @@ const _nullLong = -9223372036854775808;
 /// Generates the isar code for the annotated classes.
 Builder getIsarGenerator(BuilderOptions options) => SharedPartBuilder(
       [
-        _IsarCollectionGenerator(),
-        _IsarEmbeddedGenerator(),
+        _IsarCollectionGenerator(options.config),
+        _IsarEmbeddedGenerator(options.config),
       ],
       'isar_generator',
     );


### PR DESCRIPTION
Add a new option to the generator called `propertyMapper`, when enabled it will generate a constant `Map<String, int>` under `[Type]Schema`. This map will map the dart name of the property to the Isar property index. 

What enables this?

Well, when building a query using `.buildQuery`, it requires the property's index instead of its name. So, when creating generic structures, like repositories, you may end up with something like the following:

```
abstract class Repository<T> {
    T? find(String id);
}
``` 

```
// maybe this can be generated too
const _schemas = <Type, Map<String, int>>{
     User: UserPropertyMapper,
     Order: OrderPropertyMapper
};

class IsarRepository<T> implements Repository<T> {
   T? find(String id) => _isar.collection<int, T>().buildQuery(
        filter: EqualCondition(property: _schemas[T].mapper["id"])
   );
}
```

Hope this helps more people like me :)