### PR TITLE
Update build.gradle

### DIFF
--- a/packages/isar_flutter_libs/android/build.gradle
+++ b/packages/isar_flutter_libs/android/build.gradle
@@ -22,9 +22,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    if (project.android.hasProperty("namespace")) {
-        namespace 'dev.isar.isar_flutter_libs'
-    }
+    
+    namespace 'dev.isar.isar_flutter_libs'
     
     compileSdkVersion 30
 


### PR DESCRIPTION
Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

     android {
         namespace 'com.example.namespace'
     }