### PR TITLE
Support for Duration object as double

### DIFF
--- a/docs/docs/schema.md
+++ b/docs/docs/schema.md
@@ -124,6 +124,7 @@ Isar supports the following data types:
 - `float`
 - `double`
 - `DateTime`
+- `Duration`
 - `String`
 - `List<bool>`
 - `List<byte>`
@@ -132,6 +133,7 @@ Isar supports the following data types:
 - `List<float>`
 - `List<double>`
 - `List<DateTime>`
+- `List<Duration>`
 - `List<String>`
 
 Additionally, embedded objects and enums are supported. We'll cover those below.
@@ -195,6 +197,10 @@ The `byte` type does not support null values.
 Isar does not store timezone information of your dates. Instead, it converts `DateTime`s to UTC before storing them. Isar returns all dates in local time.
 
 `DateTime`s are stored with microsecond precision. In browsers, only millisecond precision is supported because of JavaScript limitations.
+
+## Duration
+
+Durations are stored in millisecond precision.
 
 ## Enum
 

--- a/packages/isar/lib/src/generator/code_gen/deserialize_generator.dart
+++ b/packages/isar/lib/src/generator/code_gen/deserialize_generator.dart
@@ -204,7 +204,16 @@ String _deserialize({
             ${transform('DateTime.fromMicrosecondsSinceEpoch(value, isUtc: true)$toLocal')}
           }
         }''';
-
+    case IsarType.duration:
+      return '''
+        {
+          final value = IsarCore.readLong(reader, $index);
+          if (value == $_nullLong) {
+            ${transform(defaultValue)}
+          } else {
+            ${transform('Duration(milliseconds: value)')}
+          }
+        }''';
     case IsarType.double:
       if (defaultValue == 'double.nan') {
         return transform('IsarCore.readDouble(reader, $index)');
@@ -246,6 +255,7 @@ String _deserialize({
     case IsarType.floatList:
     case IsarType.longList:
     case IsarType.dateTimeList:
+    case IsarType.durationList:
     case IsarType.doubleList:
     case IsarType.stringList:
     case IsarType.objectList:

--- a/packages/isar/lib/src/generator/code_gen/serialize_generator.dart
+++ b/packages/isar/lib/src/generator/code_gen/serialize_generator.dart
@@ -84,6 +84,11 @@ String _writeProperty({
           ? '$value$enumGetter?.toUtc().microsecondsSinceEpoch ?? $_nullLong'
           : '$value$enumGetter.toUtc().microsecondsSinceEpoch';
       return 'IsarCore.writeLong($writer, $index, $converted);';
+    case IsarType.duration:
+      final converted = nullable
+          ? '$value$enumGetter?.inMicroseconds ?? $_nullLong'
+          : '$value$enumGetter?.inMicroseconds';
+      return 'IsarCore.writeLong($writer, $index, $converted);';
     case IsarType.double:
       final orNull = nullable ? '?? double.nan' : '';
       return 'IsarCore.writeDouble($writer, $index, $value$enumGetter$orNull);';
@@ -128,6 +133,7 @@ String _writeProperty({
     case IsarType.floatList:
     case IsarType.longList:
     case IsarType.dateTimeList:
+    case IsarType.durationList:
     case IsarType.doubleList:
     case IsarType.stringList:
     case IsarType.objectList:

--- a/packages/isar/lib/src/generator/code_gen/update_generator.dart
+++ b/packages/isar/lib/src/generator/code_gen/update_generator.dart
@@ -8,6 +8,7 @@ const _updateableTypes = [
   IsarType.float,
   IsarType.double,
   IsarType.dateTime,
+  IsarType.duration,
   IsarType.string,
 ];
 

--- a/packages/isar/lib/src/generator/isar_analyzer.dart
+++ b/packages/isar/lib/src/generator/isar_analyzer.dart
@@ -336,6 +336,8 @@ class _IsarAnalyzer {
       return "''";
     } else if (type.isDartCoreDateTime) {
       return 'DateTime.fromMillisecondsSinceEpoch(0, isUtc: true).toLocal()';
+    } else if (type.isDartCoreDuration) {
+      return 'Duration.zero';
     } else if (type.isDartCoreList) {
       return 'const <${type.scalarType}>[]';
     } else if (type.isDartCoreMap) {

--- a/packages/isar/lib/src/generator/isar_type.dart
+++ b/packages/isar/lib/src/generator/isar_type.dart
@@ -1,10 +1,14 @@
 part of isar_generator;
 
 const TypeChecker _dateTimeChecker = TypeChecker.fromRuntime(DateTime);
+const TypeChecker _durationChecker = TypeChecker.fromRuntime(Duration);
 
 extension on DartType {
   bool get isDartCoreDateTime =>
       element != null && _dateTimeChecker.isExactly(element!);
+
+  bool get isDartCoreDuration =>
+      element != null && _durationChecker.isExactly(element!);
 
   IsarType? get _primitiveIsarType {
     if (isDartCoreBool) {
@@ -27,6 +31,8 @@ extension on DartType {
       return IsarType.string;
     } else if (isDartCoreDateTime) {
       return IsarType.dateTime;
+    } else if (isDartCoreDuration) {
+      return IsarType.duration;
     } else if (element!.embeddedAnnotation != null) {
       return IsarType.object;
     } else if (this is DynamicType) {

--- a/packages/isar/lib/src/generator/object_info.dart
+++ b/packages/isar/lib/src/generator/object_info.dart
@@ -100,6 +100,9 @@ class PropertyInfo {
       case IsarType.dateTime:
       case IsarType.dateTimeList:
         return 'DateTime';
+      case IsarType.duration:
+      case IsarType.durationList:
+        return 'Duration';
       case IsarType.object:
       case IsarType.objectList:
         return typeClassName;

--- a/packages/isar/lib/src/isar_schema.dart
+++ b/packages/isar/lib/src/isar_schema.dart
@@ -194,6 +194,9 @@ enum IsarType {
   /// date and time stored in UTC (8 bytes)
   dateTime('DateTime'),
 
+  /// duration
+  duration('Duration'),
+
   /// string (6 + length bytes)
   string('String'),
 
@@ -224,6 +227,9 @@ enum IsarType {
   /// list of dates and times stored in UTC (6 + length * 8 bytes)
   dateTimeList('DateTimeList'),
 
+  /// list of durations
+  durationList('DurationList'),
+
   /// list of strings (6 + length * (6 + length) bytes)
   stringList('StringList'),
 
@@ -253,7 +259,9 @@ extension IsarTypeX on IsarType {
       this == IsarType.int ||
       this == IsarType.int ||
       this == IsarType.long ||
-      this == IsarType.longList;
+      this == IsarType.longList ||
+      this == IsarType.duration ||
+      this == IsarType.durationList;
 
   /// @nodoc
   bool get isNum => isFloat || isInt;
@@ -287,6 +295,8 @@ extension IsarTypeX on IsarType {
         return IsarType.double;
       case IsarType.dateTimeList:
         return IsarType.dateTime;
+      case IsarType.durationList:
+        return IsarType.duration;
       case IsarType.stringList:
         return IsarType.string;
       case IsarType.objectList:
@@ -314,6 +324,8 @@ extension IsarTypeX on IsarType {
         return IsarType.doubleList;
       case IsarType.dateTime:
         return IsarType.dateTimeList;
+      case IsarType.duration:
+        return IsarType.durationList;
       case IsarType.string:
         return IsarType.stringList;
       case IsarType.object:

--- a/packages/isar_inspector/lib/query_builder/query_filter.dart
+++ b/packages/isar_inspector/lib/query_builder/query_filter.dart
@@ -176,11 +176,13 @@ extension on IsarPropertySchema {
       case IsarType.long:
       case IsarType.double:
       case IsarType.dateTime:
+      case IsarType.duration:
       case IsarType.intList:
       case IsarType.floatList:
       case IsarType.longList:
       case IsarType.doubleList:
       case IsarType.dateTimeList:
+      case IsarType.durationList:
         return [
           FilterType.equalTo,
           FilterType.greaterThan,

--- a/packages/isar_inspector/lib/util.dart
+++ b/packages/isar_inspector/lib/util.dart
@@ -37,6 +37,8 @@ extension TypeName on IsarType {
         return 'double';
       case IsarType.dateTime:
         return 'DateTime';
+      case IsarType.duration:
+        return 'Duration';
       case IsarType.string:
         return 'String';
       case IsarType.object:
@@ -57,6 +59,8 @@ extension TypeName on IsarType {
         return 'List<double>';
       case IsarType.dateTimeList:
         return 'List<DateTime>';
+      case IsarType.durationList:
+        return 'List<Duration>';
       case IsarType.stringList:
         return 'List<String>';
       case IsarType.objectList:


### PR DESCRIPTION
Duration objects are just an integer, converted to seconds, hours etc. Duration are stored with milliseconds precision as double and converted back accordingly.

Fixes #1537