### PR TITLE
Fix: Change duration serializer to miliseconds

### DIFF
--- a/packages/isar/lib/src/generator/code_gen/serialize_generator.dart
+++ b/packages/isar/lib/src/generator/code_gen/serialize_generator.dart
@@ -86,8 +86,8 @@ String _writeProperty({
       return 'IsarCore.writeLong($writer, $index, $converted);';
     case IsarType.duration:
       final converted = nullable
-          ? '$value$enumGetter?.inMicroseconds ?? $_nullLong'
-          : '$value$enumGetter?.inMicroseconds';
+          ? '$value$enumGetter?.inMilliseconds ?? $_nullLong'
+          : '$value$enumGetter?.inMilliseconds';
       return 'IsarCore.writeLong($writer, $index, $converted);';
     case IsarType.double:
       final orNull = nullable ? '?? double.nan' : '';


### PR DESCRIPTION
While implementing #1537 via #1571, a typo slipped through the serializer logic such as the Duration was serialized in microseconds instead of miliseconds like the documentation, and deserializer were expecting.

Fixes #1571